### PR TITLE
Add docker networking. Update access to response data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,10 @@ services:
       - "3000:3000"
     environment:
       NODE_ENV: development
+    networks:
+      - marketplace
+
+networks:
+  marketplace:
+    name: marketplace
+    external: true

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -9,10 +9,11 @@ export async function fetchData(query?: string): Promise<Resource[]> {
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
     );
   }
-  const response = await axios.get<ApiResponse[]>(apiUrl as string);
+  const response = await axios.get<ApiResponse>(apiUrl as string);
 
   // Flatten the array of data
-  let resources = response.data.flatMap((apiResponse) => apiResponse.data);
+  // let resources = response.data.flatMap((apiResponse) => apiResponse.data);
+  let resources = response.data.data;
 
   // Search the data if query is present
   if (query) {


### PR DESCRIPTION
# Interop with backend
Some changes that were required to get the frontend and backend working together when running them both locally.

## Docker network
The docker containers need to be on the same network to be able to communicate with each other.
I've added an external network to the docker-compose file, which is created when the API containers start up, so that the frontend and backend end up on the same network.
This means that the API containers need to be started up before the frontend. I'll look into whether there's a way around this, so the containers can be started in any order.

## Frontend changes
Made a minor change to the frontend code to access the `data` directly from the `response.data` object.
I'd be happy to rename `data` to `assets` or something in the API response, to avoid having this slightly confusing `response.data.data`. So it could be `response.data.assets` instead. But I imagine that might also then require changes to the mock data, which might not be worth the effort.