### PR TITLE
Append /catalogue to API endpoint in resource fetch methods

### DIFF
--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -25,7 +25,7 @@ describe('fetchResources', () => {
     const result = await fetchResources();
 
     expect(result).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(process.env.API_ENDPOINT);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
 
   it('should return filtered data when a query is provided', async () => {
@@ -37,7 +37,7 @@ describe('fetchResources', () => {
     });
     const result = await fetchResources(query);
     expect(result).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(process.env.API_ENDPOINT);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   })
 
   it('should throw an error when the axios request fails', async () => {

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -9,7 +9,7 @@ import {
 export async function fetchResources(
   query?: string,
 ): Promise<(DataSetResource | DataServiceResource)[]> {
-  const apiUrl = process.env.API_ENDPOINT;
+  const apiUrl = `${process.env.API_ENDPOINT}/catalogue`;
   if (!apiUrl) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
@@ -46,7 +46,7 @@ export async function fetchResources(
 export async function fetchResourceById(
   resourceID: string,
 ): Promise<DataSetResource | DataServiceResource> {
-  const apiUrl = process.env.API_ENDPOINT;
+  const apiUrl = `${process.env.API_ENDPOINT}/catalogue`;
   if (!apiUrl) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",


### PR DESCRIPTION
Update the fetch methods to use the base URL variable stored in .env and append with `/catalogue`.
Refactor tests to check for this new URL.