### PR TITLE
bugfix: re-configure Helmet's CSP directive 'upgrade-insecure-requests'

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,12 +13,14 @@ import { handleCookies } from "./middleware/cookieMiddleware";
 
 export const app = express();
 // Set up security headers with Helmet
+const upgradeDirective = process.env.NODE_ENV === "production" ? [] : null;
 app.use(
   helmet({
     contentSecurityPolicy: {
       directives: {
         "script-src": ["'self'", "'unsafe-inline'", "http://localhost:3000"],
         "style-src": ["'self'", "'unsafe-inline'"],
+        "upgrade-insecure-requests": upgradeDirective,
       },
     },
   }),


### PR DESCRIPTION
Styles were not loading on Safari. After emulating Safari on my machine using Playwright, I found there were SSL errors in the console. The issue was narrowed down to part of Helmet's default CSP directive 'upgrade-insecure-requests' which instructs browsers to treat all insecure URLs (HTTP) as though they have been replaced with secure URLs (HTTPS). 
The directive is now set to only apply to production environments as it is not necessary to set this directive for local development.