### PR TITLE
Adds /logout to loginRoutes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -108,7 +108,7 @@ app.use((req, res, next) => {
   modifyApplicationMiddleware(req, res, next);
 });
 
-app.use("/login", loginRoutes);
+app.use("/", loginRoutes);
 app.use("/auth", authRoutes);
 app.use("/", homeRoute);
 app.use("/profile", profileRoutes);

--- a/src/routes/loginRoutes.ts
+++ b/src/routes/loginRoutes.ts
@@ -3,12 +3,22 @@ const router = express.Router();
 import passport from "passport";
 
 router.get(
-  "/",
+  "/login",
   passport.authenticate("custom-sso"),
   (req: Request, res: Response, next: NextFunction) => {
     res.cookie("jwtToken", false, { httpOnly: true });
     next();
   },
 );
+
+router.get(
+  '/logout',
+  (req: Request, res: Response, next: NextFunction) => {
+    req.logout(function (err) {
+      if (err) { return next(err); }
+      res.clearCookie("jwtToken");
+      res.redirect('/');
+    });
+  });
 
 export default router;


### PR DESCRIPTION
The /logout route removes the jwtToken cookie and redirects to the index.

I thought it made sense that the `/logout` lived in the same file as `/login`, but that meant also having to update the `loginRoutes` router to use `/` as its base path instead of `/login`. 
I'm happy to move `/logout` into its own router if you want to keep `loginRoutes` unchanged