### PR TITLE
Validation updates

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -3,6 +3,10 @@ import { DateStep, RequestBody, Step } from "../types/express";
 function validateDate(day: number, month: number, year: number): string {
   const errors = new Set<string>();
 
+  if (!day && !month && !year) {
+    return ""; // allows date to be null
+  }
+
   const isLeapYear = (year: number) =>
     year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
 

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -79,27 +79,6 @@ const validateRequestBody = (step: string, body: RequestBody): string => {
   let errorMessage = "";
 
   switch (step) {
-    case "data-type": {
-      break;
-    }
-    case "data-subjects": {
-      break;
-    }
-    case "project-aims": {
-      break;
-    }
-    case "data-required": {
-      break;
-    }
-    case "benefits": {
-      break;
-    }
-    case "data-access": {
-      break;
-    }
-    case "impact": {
-      break;
-    }
     case "date": {
       const dateStep: DateStep = body as DateStep;
       errorMessage = validateDate(
@@ -109,15 +88,15 @@ const validateRequestBody = (step: string, body: RequestBody): string => {
       );
       break;
     }
-    
+
     default:
-      errorMessage = "Invalid step.";
+      errorMessage = "";
   }
 
   return errorMessage;
 };
 
-const extractFormData = (stepData: Step, body: RequestBody ) => {
+const extractFormData = (stepData: Step, body: RequestBody) => {
   // Return something that will get set in the 'value' key of the form step
   // Will need to something different depending on whether the input is a radio button
   //  or text field or checkbox etc.
@@ -139,11 +118,10 @@ const extractFormData = (stepData: Step, body: RequestBody ) => {
   } else {
     if (textFields.includes(stepData.id)) {
       return body[stepData.id]
-    } 
+    }
   }
 
   if (stepData.id === 'date') {
-    console.log("date fucntion body", stepData, body)
     return {
       day: body.day || null,
       month: body.month || null,

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -25,7 +25,7 @@ router.get("/:resourceID/start", async (req: Request, res: Response) => {
 
   try {
     const resource = await fetchResourceById(resourceID);
-   
+
     if (!resource) {
       res.status(404).send("Resource not found");
       return;
@@ -57,7 +57,7 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   if (!req.session.acquirerForms?.[resourceID]) {
     return res.redirect(`/share/${resourceID}/acquirer`)
   }
-  
+
   const formdata = req.session.acquirerForms[resourceID]
   const stepData = formdata.steps[formStep]
   const assetTitle = formdata.assetTitle
@@ -83,7 +83,6 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   const formdata = req.session.acquirerForms[resourceID];
   const stepData = formdata.steps[formStep];
   const errorMessage = validateRequestBody(formStep, req.body);
-  stepData.errorMessage = errorMessage;
 
   if (!formdata || !formdata.steps[formStep]) {
     return res.status(400).send("Form data or step not found");
@@ -93,18 +92,19 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     return res.status(400).send("Step data not found");
   }
 
+  stepData.errorMessage = errorMessage;
+  stepData.value = extractFormData(stepData, req.body) || "";
+
   if (errorMessage) {
     return res.redirect(`/acquirer/${resourceID}/${formStep}`)
   }
 
   // Check which button was clicked "Save and continue || Save and return"
   if (req.body.returnButton) {
-    stepData.value = extractFormData(stepData, req.body) || "";
     stepData.status = "IN PROGRESS";
     return res.redirect(`/acquirer/${resourceID}/start`);
   }
 
-  stepData.value = extractFormData(stepData, req.body) || "";
   stepData.status = "COMPLETED";
 
   if (formdata.steps[formStep].nextStep) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -52,11 +52,7 @@ interface Step {
   value: StepValue;
   nextStep?: string;
   blockedBy?: string[];
-}
-
-type ProjectAimStep = { 
-  aims: string; 
-  explanation: string;
+  errorMessage?: string;
 }
 
 type DateStep = {

--- a/src/views/acquirer/date.njk
+++ b/src/views/acquirer/date.njk
@@ -2,6 +2,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
+{% set errorText = ({text: errorMessage}
+if errorMessage else 
+  false
+) %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -29,9 +34,7 @@
             hint: {
                 text: "For example, 02 03 2024"
             },
-            errorMessage: {
-                text: errorMessage
-            },
+            errorMessage: errorText,
             items: [{
                 name: "day",
                 value: savedValue.day,


### PR DESCRIPTION
# Validation updates
I've made some changes to the validation to fix a couple of small issues I spotted.

## Errors were always displayed
Even though the errorMessage being passed to the data.njk template was an empty string, an error was still being displayed on the page.
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/b759d2fb-9ebe-4bdf-a986-ec99d6089ede)
The gov design system documentation says:
> The error message component will not display if you use a falsy value for errorMessage, for example false or null.

So we need to pass something like `false` or `null` as the error message if we want nothing to displayed. I've updated the data.njk template to include: `{% set errorText = ({text: errorMessage} if errorMessage else false) %}` and use that to set the error message.

## Confirm form resubmission message
One issue with doing `res.render` from a `POST` route is that if the user refreshes the page for any reason they'll get a confusing "Confirm form resubmission" message, because the browser tries to re-submit the same POST request. 
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/28253574-a3e9-4e4a-8432-4835444d6a8e)
A way around this is for the `POST` route to redirect back to the `GET` route, so that any page refreshes just trigger another `GET` request, which is fine.
To make sure that the error message is still available in the njk templates I've updated the `POST` route to save the error messages to the session and updated the `GET` route to pull the error message out of the session to pass to the njk template.

## Input values disappear after submitting
If the user submitted the form with errors, the values that they entered disappeared, which means that they couldn't check what they'd entered against the error message and see what to fix.
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/e656de89-1530-4c81-a7bb-2712efb85874)
I've moved the call to `extractFormData` up, to be before the `if (errorMessage)` check, so that any form values submitted can be saved to the session before we redirect back to the same form page and display the errors.
E.g:
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/7cd470bc-cec3-4af4-8882-eeb18eaed717)

## Default error message
By default I think it's easier to assume that we're not doing any validation, and so the default error message is just empty. That way we can get rid of all the empty validation cases in `validateRequestBody`. It also means we don't have to remember to add an empty validation case when we add more steps to the form.