### PR TITLE
DMBM 719 - Hidden page functionality

### DIFF
--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -30,6 +30,7 @@
       "name": "Data protection",
       "steps": [
         "lawful-basis-personal",
+        "lawful-basis-special",
         "data-travel",
         "role",
         "protection-review"
@@ -167,7 +168,7 @@
     },
     "lawful-basis-personal": {
       "id": "lawful-basis-personal",
-      "name": "Lawful basis",
+      "name": "Lawful basis for personal data",
       "status": "NOT STARTED",
       "value": [],
       "nextStep": "lawful-basis-special",
@@ -175,7 +176,7 @@
     },
     "lawful-basis-special": {
       "id": "lawful-basis-special",
-      "name": "Lawful basis",
+      "name": "Lawful basis for special category data",
       "status": "NOT STARTED",
       "value": [],
       "nextStep": "lawful-basis-special-public-interest",

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -29,7 +29,7 @@
     "dataProtection": {
       "name": "Data protection",
       "steps": [
-        "basis",
+        "lawful-basis-personal",
         "data-travel",
         "role",
         "protection-review"
@@ -64,7 +64,8 @@
       "name": "Data subjects",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "project-aims"
+      "nextStep": "project-aims",
+      "skipped": false
     },
     "project-aims": {
       "id": "project-aims",
@@ -95,7 +96,15 @@
       "name": "Data access",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "impact"
+      "nextStep": "other-orgs"
+    },
+    "other-orgs": {
+      "id": "other-orgs",
+      "name": "Other organisations",
+      "status": "NOT STARTED",
+      "value": "",
+      "nextStep": "impact",
+      "skipped": false
     },
     "impact": {
       "id": "impact",
@@ -120,14 +129,30 @@
       "name": "Legal power",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "legal-gateway"
+      "nextStep": "legal-power-advice"
+    },
+    "legal-power-advice": {
+      "id": "legal-power-advice",
+      "name": "Legal power advice",
+      "status": "NOT STARTED",
+      "value": "",
+      "nextStep": "legal-gateway",
+      "skipped": false
     },
     "legal-gateway": {
       "id": "legal-gateway",
       "name": "Legal gateway",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "legal-review"
+      "nextStep": "legal-gateway-advice"
+    },
+    "legal-gateway-advice": {
+      "id": "legal-gateway-advice",
+      "name": "Legal gateway advice",
+      "status": "NOT STARTED",
+      "value": "",
+      "nextStep": "legal-review",
+      "skipped": false
     },
     "legal-review": {
       "id": "legal-review",
@@ -138,28 +163,54 @@
         "legal-power",
         "legal-gateway"
       ],
-      "nextStep": "basis"
+      "nextStep": "lawful-basis-personal"
     },
-    "basis": {
-      "id": "basis",
+    "lawful-basis-personal": {
+      "id": "lawful-basis-personal",
       "name": "Lawful basis",
       "status": "NOT STARTED",
-      "value": "",
-      "nextStep": "data-travel"
+      "value": [],
+      "nextStep": "lawful-basis-special",
+      "skipped": false
+    },
+    "lawful-basis-special": {
+      "id": "lawful-basis-special",
+      "name": "Lawful basis",
+      "status": "NOT STARTED",
+      "value": [],
+      "nextStep": "lawful-basis-special-public-interest",
+      "skipped": false
+    },
+    "lawful-basis-special-public-interest": {
+      "id": "lawful-basis-special-public-interest",
+      "name": "Lawful basis",
+      "status": "NOT STARTED",
+      "value": [],
+      "nextStep": "data-travel",
+      "skipped": false
     },
     "data-travel": {
       "id": "data-travel",
       "name": "Data travel outside UK",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "role"
+      "nextStep": "data-travel-location"
+    },
+    "data-travel-location": {
+      "id": "data-travel-location",
+      "name": "Data travel outside UK",
+      "status": "NOT STARTED",
+      "value": "",
+      "nextStep": "role",
+      "skipped": false
     },
     "role": {
       "id": "role",
       "name": "Role of organisation",
       "status": "NOT STARTED",
       "value": "",
-      "nextStep": "protection-review"
+      "nextStep": "protection-review",
+      "skipped": false
     },
     "protection-review": {
       "id": "protection-review",

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -4,7 +4,7 @@
   "assetTitle": "",
   "ownedBy": "",
   "status": "Request incomplete",
-  "sections": {
+  "overviewSections": {
     "purpose": {
       "name": "Purpose of the data share section",
       "steps": [

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -20,11 +20,7 @@
     },
     "legal": {
       "name": "Legal power and gateway",
-      "steps": [
-        "legal-power",
-        "legal-gateway",
-        "legal-review"
-      ]
+      "steps": ["legal-power", "legal-gateway", "legal-review"]
     },
     "dataProtection": {
       "name": "Data protection",
@@ -38,18 +34,11 @@
     },
     "security": {
       "name": "Data governance, security and technology",
-      "steps": [
-        "delivery",
-        "format",
-        "disposal",
-        "security-review"
-      ]
+      "steps": ["delivery", "format", "disposal", "security-review"]
     },
     "review": {
       "name": "Review and send",
-      "steps": [
-        "check"
-      ]
+      "steps": ["check"]
     }
   },
   "steps": {
@@ -160,10 +149,7 @@
       "name": "Legal review",
       "status": "CANNOT START YET",
       "value": "",
-      "blockedBy": [
-        "legal-power",
-        "legal-gateway"
-      ],
+      "blockedBy": ["legal-power", "legal-gateway"],
       "nextStep": "lawful-basis-personal"
     },
     "lawful-basis-personal": {
@@ -218,11 +204,7 @@
       "name": "Data protection review",
       "status": "CANNOT START YET",
       "value": "",
-      "blockedBy": [
-        "basis",
-        "data-travel",
-        "role"
-      ],
+      "blockedBy": ["basis", "data-travel", "role"],
       "nextStep": "delivery"
     },
     "delivery": {
@@ -250,22 +232,14 @@
       "name": "Data security review",
       "status": "CANNOT START YET",
       "value": "",
-      "blockedBy": [
-        "delivery",
-        "format",
-        "disposal"
-      ],
+      "blockedBy": ["delivery", "format", "disposal"],
       "nextStep": "check"
     },
     "check": {
       "id": "check",
       "name": "Check answers",
       "status": "CANNOT START YET",
-      "blockedBy": [
-        "legal-review",
-        "protection-review",
-        "security-review"
-      ]
+      "blockedBy": ["legal-review", "protection-review", "security-review"]
     }
   }
 }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -31,6 +31,10 @@ const skipThisStep = (step: string, formdata: FormData) => {
       // Skip data-subjects if the data-type is "none" i.e. anonymised
       return (formdata.steps['data-type'].value === "none")
     }
+    case "other-orgs": {
+      // Skip other-orgs if the answer to data-access was "no"
+      return (formdata.steps['data-access'].value === "no")
+    }
     default: {
       return false
     }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -4,7 +4,7 @@ const router = express.Router();
 import formTemplate from "../models/shareRequestTemplate.json"
 import { randomUUID } from "crypto";
 import { extractFormData, validateRequestBody } from "../helperFunctions/helperFunctions";
-import { FormData, Step } from "../types/express";
+import { FormData } from "../types/express";
 function parseJwt(token: string) {
   return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
 }
@@ -22,7 +22,10 @@ const generateFormTemplate = (req: Request, resourceID: string, assetTitle: stri
 
 const skipThisStep = (step: string, formdata: FormData) => {
   // Decide whether to skip the current step based on answers in previous steps
-  // Returns false by default.
+  // Returns false (doesn't skip any steps) by default, so only hidden steps or
+  // ones that might need to be skipped in some circumstances need to be added to
+  // switch/case statement.
+
   switch (step) {
     case "data-subjects": {
       // Skip data-subjects if the data-type is "none" i.e. anonymised

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -3,7 +3,10 @@ import { fetchResourceById } from "../services/findService";
 const router = express.Router();
 import formTemplate from "../models/shareRequestTemplate.json";
 import { randomUUID } from "crypto";
-import { extractFormData, validateRequestBody } from "../helperFunctions/helperFunctions";
+import {
+  extractFormData,
+  validateRequestBody,
+} from "../helperFunctions/helperFunctions";
 import { FormData } from "../types/express";
 function parseJwt(token: string) {
   return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
@@ -33,17 +36,17 @@ const skipThisStep = (step: string, formdata: FormData) => {
   switch (step) {
     case "data-subjects": {
       // Skip data-subjects if the data-type is "none" i.e. anonymised
-      return (formdata.steps['data-type'].value === "none")
+      return formdata.steps["data-type"].value === "none";
     }
     case "other-orgs": {
       // Skip other-orgs if the answer to data-access was "no"
-      return (formdata.steps['data-access'].value === "no")
+      return formdata.steps["data-access"].value === "no";
     }
     default: {
-      return false
+      return false;
     }
   }
-}
+};
 
 router.get("/:resourceID/start", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
@@ -91,8 +94,8 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   const assetTitle = formdata.assetTitle;
 
   if (skipThisStep(formStep, formdata)) {
-    stepData.skipped = true
-    return res.redirect(`/acquirer/${resourceID}/${stepData.nextStep}`)
+    stepData.skipped = true;
+    return res.redirect(`/acquirer/${resourceID}/${stepData.nextStep}`);
   }
 
   res.render(`../views/acquirer/${formStep}.njk`, {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -38,8 +38,8 @@ type BenefitsStep = {
   'something-else'?: Benefits;
 }
 
-type ProjectAimStep = { 
-  aims: string; 
+type ProjectAimStep = {
+  aims: string;
   explanation: string;
 }
 
@@ -53,6 +53,7 @@ interface Step {
   nextStep?: string;
   blockedBy?: string[];
   errorMessage?: string;
+  skipped?: boolean
 }
 
 type DateStep = {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -53,7 +53,7 @@ interface Step {
   nextStep?: string;
   blockedBy?: string[];
   errorMessage?: string;
-  skipped?: boolean
+  skipped?: boolean;
 }
 
 type DateStep = {

--- a/src/views/acquirer/start.njk
+++ b/src/views/acquirer/start.njk
@@ -2,41 +2,42 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: {{formdata.requestId}}</span>
-    <h1 class="govuk-heading-xl">
-      {{resource.title}}
-    </h1>
-    <h2 class="app-task-list__section">{{formdata.status}}</h2>
-    <p class="govuk-body govuk-!-margin-bottom-2">You have completed 0 of 5 sections.</p>
-    <p class="govuk-body govuk-!-margin-bottom-7">More sections may be added depending on your answers.</p>
-    <ol class="app-task-list">
-      {% for key, section in formdata.sections %}
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">{{ loop.index }}.</span> {{ section.name }}
-          </h2>
-          <ul class="app-task-list__items">
-            {% for step in section.steps %}
-              {% set s = formdata.steps[step] %}
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  {% if s.status != "CANNOT START YET" %}
-                    <a href="{{ s.id }}" class="govuk-link">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{formdata.requestId}}</span>
+      <h1 class="govuk-heading-xl">
+        {{resource.title}}
+      </h1>
+      <h2 class="app-task-list__section">{{formdata.status}}</h2>
+      <p class="govuk-body govuk-!-margin-bottom-2">You have completed 0 of 5 sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">More sections may be added depending on your answers.</p>
+      <ol class="app-task-list">
+        {% for key, section in formdata.overviewSections %}
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">{{ loop.index }}.</span>
+              {{ section.name }}
+            </h2>
+            <ul class="app-task-list__items">
+              {% for step in section.steps %}
+                {% set s = formdata.steps[step] %}
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    {% if s.status != "CANNOT START YET" %}
+                      <a href="{{ s.id }}" class="govuk-link">
+                        {{ s.name }}
+                      </a>
+                    {% else %}
                       {{ s.name }}
-                    </a>
-                  {% else %}
-                    {{ s.name }}
-                  {% endif %}
-                </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag">{{ s.status }}</strong>
-              </li>
-            {% endfor %}
-          </ul>
-        </li>
-      {% endfor %}
-    </ol>
+                    {% endif %}
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag">{{ s.status }}</strong>
+                </li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
+      </ol>
+    </div>
   </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
# Acquirer journey 
There are some steps in the acquirer journey which you can skip, or which you can only get routed to, if you've provided specific answers to previous questions.

For example, if you answer "None" to the `data-type` question you skip the `data-subjects` and `lawful basis` questions.
And if you answer `Yes` to the `data-access` question, you get routed to a hidden page asking for details about the other organisations that will have access to the data.

# Hidden & skippable steps
I've set the steps up so that there's only a single path through the acquirer journey, which goes through every single step. And I've added a `skipThisStep` function that is called in the `GET /acquirer/:assetID/:step` route, which is used decide whether we need to skip over the step that's about to be displayed, based on the form data that is currently saved.

For example, when we're about to load the `data-subjects` page we call `skipThisStep` and check whether the saved value from the `data-type` step was `none`. If it *was* `none` we return `true` from `skipThisStep` and redirect straight to the next step in the chain. If the `data-type` value was `personal` or `special` then we return `false` from `skipThisStep` and we do display the `data-subjects` page as normal.

There is a bit of extra complexity around the `lawful basis steps`, because there's a "Get advice" page that you can get to from two different places. It isn't easy to model this using the `previous step -> next step -> next step` setup that we've got at the moment, so I've split the "Get advice" page into two steps, one that you can get to from the `legal-power` page and one that you get to from the `legal-gateway` page. The `legal-power-advice` and `legal-gateway-advice` nunjucks templates will be identical, but having them as separate steps makes the flow through the pages simpler.

I.e instead of the original wireframe:
![Screen Shot 2023-08-18 at 1 58 06 PM](https://github.com/co-cddo/data-marketplace/assets/1217533/19c7f513-0b69-4d77-855f-7e017f22dfec)

We're going to do this:
![Screen Shot 2023-08-18 at 2 12 41 PM](https://github.com/co-cddo/data-marketplace/assets/1217533/dde78177-90ca-4e53-b68b-ff3675798f8e)
where the two `...-advice` `njk` templates will be identical, and those steps can easily be skipped if they don't need to be shown.

The path of steps through the acquire journey is now (where [*] means that the step can be skipped):
```
data-type
data-subjects [*]
project-aims
data-required
benefits
data-access
other-orgs  [*]
impact
date
legal-power
legal-power-advice [*]
legal-gateway
legal-gateway-advice [*]
legal-review
lawful-basis-personal [*]
lawful-basis-special [*]
lawful-basis-special-public-interest [*]
data-travel
data-travel-location [*]
role [*]
delivery
format
disposal
security-review
check
declaration (I've not added this one to the steps yet)
```

I've added the logic for the `data-subjects` and `other-orgs` pages. The `njk` template for `other-orgs` doesn't exist yet, not sure if there's a Jira ticket for it, so that page is currently just a 404.

Hopefully it shouldn't too hard to add in the logic for the other hidden/skippable routes to the `skipThisStep` function.