### PR TITLE
Dmbm 707/dataprotection lawful basis for personal data

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -1,4 +1,17 @@
-import { BenefitsStep, DateStep, LawfulBasisPersonalStep, LawfulBasisSpecialStep, LegalGatewayStep, LegalPowerStep, ProjectAimStep,  RequestBody, Step, StepValue, RadioFieldStepID, TextFieldStepID } from "../types/express";
+import {
+  BenefitsStep,
+  DateStep,
+  LawfulBasisPersonalStep,
+  LawfulBasisSpecialStep,
+  LegalGatewayStep,
+  LegalPowerStep,
+  ProjectAimStep,
+  RequestBody,
+  Step,
+  StepValue,
+  RadioFieldStepID,
+  TextFieldStepID,
+} from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
   const errors = new Set<string>();
@@ -126,7 +139,7 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   if (isRadioField(stepData.id)) {
     return body[stepData.id] as StepValue;
   }
- 
+
   // Check for text fields
   if (isTextField(stepData.id)) {
     return body[stepData.id] as StepValue;
@@ -190,58 +203,55 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
 
   if (stepData.id === "legal-power") {
     return {
-      "yes": {
+      yes: {
         explanation: body["legal-power-textarea"] || "",
-        checked: body["legal-power"] === "yes"
+        checked: body["legal-power"] === "yes",
       },
-      "no": {
+      no: {
         explanation: body["legal-power-textarea"] || "",
-        checked: body["legal-power"] === "no"
+        checked: body["legal-power"] === "no",
       },
       "we-dont-know": {
-        checked: body["legal-power"] === "we-dont-know"
-      }
+        checked: body["legal-power"] === "we-dont-know",
+      },
     } as LegalPowerStep;
   }
 
   if (stepData.id === "legal-gateway") {
     return {
-      "yes": {
-        explanation: body["legal-gateway"] === "yes"
-          ? body["yes"]
-          : "",
-        checked: body["legal-gateway"] === "yes"
+      yes: {
+        explanation: body["legal-gateway"] === "yes" ? body["yes"] : "",
+        checked: body["legal-gateway"] === "yes",
       },
-      "other": {
-        explanation: body["legal-gateway"] === "other"
-          ? body["other"]
-          : "",
-        checked: body["legal-gateway"] === "other"
+      other: {
+        explanation: body["legal-gateway"] === "other" ? body["other"] : "",
+        checked: body["legal-gateway"] === "other",
       },
       "we-dont-know": {
-        explanation: body["legal-gateway"] === "we-dont-know"
-          ? body["we-dont-know"]
-          : "",
-        checked: body["legal-gateway"] === "we-dont-know"
-      }
+        explanation:
+          body["legal-gateway"] === "we-dont-know" ? body["we-dont-know"] : "",
+        checked: body["legal-gateway"] === "we-dont-know",
+      },
     } as LegalGatewayStep;
   }
 
   if (stepData.id === "lawful-basis-personal") {
-      return {
+    return {
       "public-task": {
         checked: body["lawful-basis-personal"]?.includes("public-task"),
       },
       "legal-obligation": {
         checked: body["lawful-basis-personal"]?.includes("legal-obligation"),
       },
-      "contract": {
+      contract: {
         checked: body["lawful-basis-personal"]?.includes("contract"),
       },
       "legitimate-interests": {
-        checked: body["lawful-basis-personal"]?.includes("legitimate-interests"),
+        checked: body["lawful-basis-personal"]?.includes(
+          "legitimate-interests",
+        ),
       },
-      "consent": {
+      consent: {
         checked: body["lawful-basis-personal"]?.includes("consent"),
       },
       "vital-interest": {
@@ -252,23 +262,31 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
       },
     } as LawfulBasisPersonalStep;
   }
- 
+
   if (stepData.id === "lawful-basis-special") {
-      return {
+    return {
       "reasons-of-public-interest": {
-        checked: body["lawful-basis-special"]?.includes("reasons-of-public-interest"),
+        checked: body["lawful-basis-special"]?.includes(
+          "reasons-of-public-interest",
+        ),
       },
       "legal-claim-or-judicial-acts": {
-        checked: body["lawful-basis-special"]?.includes("legal-claim-or-judicial-acts"),
+        checked: body["lawful-basis-special"]?.includes(
+          "legal-claim-or-judicial-acts",
+        ),
       },
       "public-health": {
         checked: body["lawful-basis-special"]?.includes("public-health"),
       },
       "health-or-social-care": {
-        checked: body["lawful-basis-special"]?.includes("health-or-social-care"),
+        checked: body["lawful-basis-special"]?.includes(
+          "health-or-social-care",
+        ),
       },
       "social-employment-security-and-protection": {
-        checked: body["lawful-basis-special"]?.includes("social-employment-security-and-protection"),
+        checked: body["lawful-basis-special"]?.includes(
+          "social-employment-security-and-protection",
+        ),
       },
       "vital-interests": {
         checked: body["lawful-basis-special"]?.includes("vital-interests"),
@@ -277,13 +295,19 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
         checked: body["lawful-basis-special"]?.includes("explicit-consent"),
       },
       "public-by-data-subject": {
-        checked: body["lawful-basis-special"]?.includes("public-by-data-subject"),
+        checked: body["lawful-basis-special"]?.includes(
+          "public-by-data-subject",
+        ),
       },
       "archiving-researching-statistics": {
-        checked: body["lawful-basis-special"]?.includes("archiving-researching-statistics"),
+        checked: body["lawful-basis-special"]?.includes(
+          "archiving-researching-statistics",
+        ),
       },
       "not-for-profit-bodies": {
-        checked: body["lawful-basis-special"]?.includes("not-for-profit-bodies"),
+        checked: body["lawful-basis-special"]?.includes(
+          "not-for-profit-bodies",
+        ),
       },
     } as LawfulBasisSpecialStep;
   }

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -116,6 +116,7 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
 
   const radioFields = ["data-type", "data-access", "legal-review"];
   const textFields = ["impact", "data-subjects", "data-required"];
+  const checkBoxes = ["basis"]
 
   if (radioFields.includes(stepData.id)) {
     return body[stepData.id];
@@ -209,6 +210,10 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
         checked: body["legal-gateway"]?.includes("dont-know-decision"),
       },
     };
+  }
+  
+  if (checkBoxes.includes(stepData.id)){
+    return body[stepData.id];
   }
   
   // Other input types can go here

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -213,7 +213,6 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
 
 
   if (stepData.id === "lawful-basis-personal") {
-    console.log("test ", stepData, body)
       return {
       "public-task": {
         checked: body["lawful-basis-personal"]?.includes("public-task"),
@@ -243,6 +242,41 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
     }
   }
  
+  if (stepData.id === "lawful-basis-special") {
+      return {
+      "reasons-of-public-interest": {
+        checked: body["lawful-basis-special"]?.includes("reasons-of-public-interest"),
+      },
+      "legal-claim-or-judicial-acts": {
+        checked: body["lawful-basis-special"]?.includes("legal-claim-or-judicial-acts"),
+      },
+      "public-health": {
+        checked: body["lawful-basis-special"]?.includes("public-health"),
+      },
+      "health-or-social-care": {
+        checked: body["lawful-basis-special"]?.includes("health-or-social-care"),
+      },
+      "social-employment-security-and-protection": {
+        checked: body["lawful-basis-special"]?.includes("social-employment-security-and-protection"),
+      },
+      "vital-interests": {
+        checked: body["lawful-basis-special"]?.includes("vital-interests"),
+      },
+      "explicit-consent": {
+        checked: body["lawful-basis-special"]?.includes("explicit-consent"),
+      },
+      "public-by-data-subject": {
+        checked: body["lawful-basis-special"]?.includes("public-by-data-subject"),
+      },
+      "archiving-researching-statistics": {
+        checked: body["lawful-basis-special"]?.includes("archiving-researching-statistics"),
+      },
+      "not-for-profit-bodies": {
+        checked: body["lawful-basis-special"]?.includes("not-for-profit-bodies"),
+      },
+    }
+  }
+
   // Other input types can go here
   return;
 };

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -211,11 +211,13 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
       },
     };
   }
-  
-  if (checkBoxes.includes(stepData.id)){
+
+  if (stepData.id === "basis") {
+    return body["basis"];
+  } else if (checkBoxes.includes(stepData.id)) {
     return body[stepData.id];
   }
-  
+
   // Other input types can go here
   return;
 };

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -116,7 +116,6 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
 
   const radioFields = ["data-type", "data-access", "legal-review"];
   const textFields = ["impact", "data-subjects", "data-required"];
-  const checkBoxes = ["lawful-basis-special"];
 
   if (radioFields.includes(stepData.id)) {
     return body[stepData.id];
@@ -212,10 +211,38 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
     };
   }
 
-  if (checkBoxes.includes(stepData.id)) {
-    return body[stepData.id];
-  }
 
+  if (stepData.id === "lawful-basis-personal") {
+    console.log("test ", stepData, body)
+      return {
+      "public-task": {
+        checked: body["lawful-basis-personal"]?.includes("public-task"),
+      },
+      "legal-obligation": {
+        checked: body["lawful-basis-personal"]?.includes("legal-obligation"),
+      },
+      "contract": {
+        checked: body["lawful-basis-personal"]?.includes("contract"),
+      },
+      "legitimate-interests": {
+        checked: body["lawful-basis-personal"]?.includes("legitimate-interests"),
+      },
+      "consent": {
+        checked: body["lawful-basis-personal"]?.includes("consent"),
+      },
+      "vital-interest": {
+        checked: body["lawful-basis-personal"]?.includes("vital-interest"),
+      },
+      "law-enforcement": {
+        checked: body["lawful-basis-personal"]?.includes("law-enforcement"),
+      },
+    }
+  } else {
+    if (textFields.includes(stepData.id)) {
+      return body[stepData.id];
+    }
+  }
+ 
   // Other input types can go here
   return;
 };

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -116,7 +116,7 @@ const extractFormData = (stepData: Step, body: RequestBody) => {
 
   const radioFields = ["data-type", "data-access", "legal-review"];
   const textFields = ["impact", "data-subjects", "data-required"];
-  const checkBoxes = ["basis"]
+  const checkBoxes = ["basis"];
 
   if (radioFields.includes(stepData.id)) {
     return body[stepData.id];

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -125,7 +125,7 @@
       "id": "basis",
       "name": "Lawful basis",
       "status": "NOT STARTED",
-      "value": "",
+      "value": [],
       "nextStep": "data-travel"
     },
     "data-travel": {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -22,6 +22,20 @@ interface Benefits {
   checked?: boolean;
 }
 
+interface LawfulBasisPersonal {
+  checked?: boolean;
+}
+
+type LawfulBasisPersonalStep = {
+  "public-task"?: LawfulBasisPersonal;
+  "legal-obligation"?: LawfulBasisPersonal;
+  "contract"?: LawfulBasisPersonal;
+  "legitimate-interests"?: LawfulBasisPersonal;
+  "consent"?: LawfulBasisPersonal;
+  "vital-interests"?: LawfulBasisPersonal;
+  "law-enforcement"?: LawfulBasisPersonal;
+}
+
 export interface RequestBody {
   [key: string]: string | undefined;
 }
@@ -48,7 +62,7 @@ type LegalPowerStep = {
   explanation: string;
 };
 
-type StepValue = string | ProjectAimStep | BenefitsStep | LegalPowerStep;
+type StepValue = string | ProjectAimStep | BenefitsStep | LegalPowerStep | LawfulBasisPersonalStep;
 
 interface Step {
   id: string;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -53,14 +53,14 @@ type LegalDecision = {
 };
 
 type LegalPowerStep = {
-  "yes": LegalDecision;
-  "no": LegalDecision;
+  yes: LegalDecision;
+  no: LegalDecision;
   "we-dont-know": LegalDecision;
 };
 
 type LegalGatewayStep = {
-  "yes": LegalDecision;
-  "other": LegalDecision;
+  yes: LegalDecision;
+  other: LegalDecision;
   "we-dont-know": LegalDecision;
 };
 
@@ -71,12 +71,12 @@ interface LawfulBasis {
 type LawfulBasisPersonalStep = {
   "public-task"?: LawfulBasis;
   "legal-obligation"?: LawfulBasis;
-  "contract"?: LawfulBasis;
+  contract?: LawfulBasis;
   "legitimate-interests"?: LawfulBasis;
-  "consent"?: LawfulBasis;
+  consent?: LawfulBasis;
   "vital-interests"?: LawfulBasis;
   "law-enforcement"?: LawfulBasis;
-}
+};
 
 type LawfulBasisSpecialStep = {
   "reasons-of-public-interest"?: LawfulBasis;
@@ -89,15 +89,16 @@ type LawfulBasisSpecialStep = {
   "public-by-data-subject"?: LawfulBasis;
   "archiving-researching-statistics"?: LawfulBasis;
   "not-for-profit-bodies"?: LawfulBasis;
-}
+};
 
-export type StepValue = string 
-  | ProjectAimStep 
-  | BenefitsStep 
-  | LegalPowerStep 
+export type StepValue =
+  | string
+  | ProjectAimStep
+  | BenefitsStep
+  | LegalPowerStep
   | LegalGatewayStep
   | DateStep
-  | LawfulBasisPersonalStep 
+  | LawfulBasisPersonalStep
   | LawfulBasisSpecialStep;
 
 interface Step {
@@ -116,7 +117,6 @@ type DateStep = {
   month?: number | null;
   year?: number | null;
 };
-
 
 interface Section {
   name: string;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -22,18 +22,31 @@ interface Benefits {
   checked?: boolean;
 }
 
-interface LawfulBasisPersonal {
+interface LawfulBasis {
   checked?: boolean;
 }
 
 type LawfulBasisPersonalStep = {
-  "public-task"?: LawfulBasisPersonal;
-  "legal-obligation"?: LawfulBasisPersonal;
-  "contract"?: LawfulBasisPersonal;
-  "legitimate-interests"?: LawfulBasisPersonal;
-  "consent"?: LawfulBasisPersonal;
-  "vital-interests"?: LawfulBasisPersonal;
-  "law-enforcement"?: LawfulBasisPersonal;
+  "public-task"?: LawfulBasis;
+  "legal-obligation"?: LawfulBasis;
+  "contract"?: LawfulBasis;
+  "legitimate-interests"?: LawfulBasis;
+  "consent"?: LawfulBasis;
+  "vital-interests"?: LawfulBasis;
+  "law-enforcement"?: LawfulBasis;
+}
+
+type LawfulBasisSpecialStep = {
+  "reasons-of-public-interest"?: LawfulBasis;
+  "legal-claim-or-judicial-acts"?: LawfulBasis;
+  "public-health"?: LawfulBasis;
+  "health-or-social-care"?: LawfulBasis;
+  "social-employment-security-and-protection"?: LawfulBasis;
+  "vital-interests"?: LawfulBasis;
+  "explicit-consent"?: LawfulBasis;
+  "public-by-data-subject"?: LawfulBasis;
+  "archiving-researching-statistics"?: LawfulBasis;
+  "not-for-profit-bodies"?: LawfulBasis;
 }
 
 export interface RequestBody {
@@ -62,7 +75,8 @@ type LegalPowerStep = {
   explanation: string;
 };
 
-type StepValue = string | ProjectAimStep | BenefitsStep | LegalPowerStep | LawfulBasisPersonalStep;
+type StepValue = string | ProjectAimStep | BenefitsStep |
+LegalPowerStep | LawfulBasisPersonalStep | LawfulBasisSpecialStep;
 
 interface Step {
   id: string;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -17,10 +17,52 @@ interface FormData {
   steps: Record<string, Step>;
 }
 
+export interface RequestBody {
+  [key: string]: string | undefined;
+}
+
+// Add id's here. Should only be able to handle single value
+type TextFieldStepID = "impact" | "data-subjects" | "data-required";
+type RadioFieldStepID = "data-type" | "data-access" | "legal-review";
+
 interface Benefits {
   explanation?: string;
   checked?: boolean;
 }
+
+type BenefitsStep = {
+  "decision-making"?: Benefits;
+  "service-delivery"?: Benefits;
+  "benefit-people"?: Benefits;
+  "allocate-and-evaluate-funding"?: Benefits;
+  "social-economic-trends"?: Benefits;
+  "needs-of-the-public"?: Benefits;
+  "statistical-information"?: Benefits;
+  "existing-research-or-statistics"?: Benefits;
+  "something-else"?: Benefits;
+};
+
+type ProjectAimStep = {
+  aims: string;
+  explanation: string;
+};
+
+type LegalDecision = {
+  explanation?: string;
+  checked: boolean;
+};
+
+type LegalPowerStep = {
+  "yes": LegalDecision;
+  "no": LegalDecision;
+  "we-dont-know": LegalDecision;
+};
+
+type LegalGatewayStep = {
+  "yes": LegalDecision;
+  "other": LegalDecision;
+  "we-dont-know": LegalDecision;
+};
 
 interface LawfulBasis {
   checked?: boolean;
@@ -49,37 +91,17 @@ type LawfulBasisSpecialStep = {
   "not-for-profit-bodies"?: LawfulBasis;
 }
 
-export interface RequestBody {
-  [key: string]: string | undefined;
-}
-
-type BenefitsStep = {
-  "decision-making"?: Benefits;
-  "service-delivery"?: Benefits;
-  "benefit-people"?: Benefits;
-  "allocate-and-evaluate-funding"?: Benefits;
-  "social-economic-trends"?: Benefits;
-  "needs-of-the-public"?: Benefits;
-  "statistical-information"?: Benefits;
-  "existing-research-or-statistics"?: Benefits;
-  "something-else"?: Benefits;
-};
-
-type ProjectAimStep = {
-  aims: string;
-  explanation: string;
-};
-
-type LegalPowerStep = {
-  decision: "yes" | "no" | "we don't know";
-  explanation: string;
-};
-
-type StepValue = string | ProjectAimStep | BenefitsStep |
-LegalPowerStep | LawfulBasisPersonalStep | LawfulBasisSpecialStep;
+export type StepValue = string 
+  | ProjectAimStep 
+  | BenefitsStep 
+  | LegalPowerStep 
+  | LegalGatewayStep
+  | DateStep
+  | LawfulBasisPersonalStep 
+  | LawfulBasisSpecialStep;
 
 interface Step {
-  id: string;
+  id: TextFieldStepID | RadioFieldStepID | string;
   name: string;
   status: string;
   value: StepValue;
@@ -94,6 +116,7 @@ type DateStep = {
   month?: number | null;
   year?: number | null;
 };
+
 
 interface Section {
   name: string;

--- a/src/views/acquirer/basis.njk
+++ b/src/views/acquirer/basis.njk
@@ -29,44 +29,54 @@
             },
             items: [
                 {
-                value: "checbox1",
-                text: "Reasons of substantial public interest (with a basis in law)"
+                value: "basis-checkbox1",
+                text: "Reasons of substantial public interest (with a basis in law)",
+                checked: savedValue === 'basis-checkbox1'
                 },
                 {
-                value: "checbox2",
-                text: "Legal claims or judicial acts"
+                value: "basis-checkbox2",
+                text: "Legal claims or judicial acts",
+                checked: savedValue === 'basis-checkbox2'
                 },
                 {
-                value: "checbox3",
-                text: "Public health (with a basis in law)"
+                value: "basis-checkbox3",
+                text: "Public health (with a basis in law)",
+                checked: savedValue === 'basis-checkbox3'
                 },
                 {
-                value: "checbox4",
-                text: "Health or social care (with a basis in law)"
+                value: "basis-checkbox4",
+                text: "Health or social care (with a basis in law)",
+                checked: savedValue === 'basis-checkbox4'
                 },
                 {
-                value: "checbox5",
-                text: "Employment, social security and social protection (if authorised by law)"
+                value: "basis-checkbox5",
+                text: "Employment, social security and social protection (if authorised by law)",
+                checked: savedValue === 'basis-checkbox5'
                 },
                 {
-                value: "checbox6",
-                text: "Vital interests"
+                value: "basis-checkbox6",
+                text: "Vital interests",
+                checked: savedValue === 'basis-checkbox6'
                 },
                 {
-                value: "checbox7",
-                text: "Explicit consent"
+                value: "basis-checkbox7",
+                text: "Explicit consent",
+                checked: savedValue === 'basis-checkbox7'
                 },
                 {
-                value: "checbox8",
-                text: "Made public by the data subject"
+                value: "basis-checkbox8",
+                text: "Made public by the data subject",
+                checked: savedValue === 'basis-checkbox8'
                 },
                 {
-                value: "checbox9",
-                text: "Archiving, research and statistics (with a basis in law)"
+                value: "basis-checkbox9",
+                text: "Archiving, research and statistics (with a basis in law)",
+                checked: savedValue === 'basis-checkbox9'
                 },
                 {
-                value: "checbox10",
-                text: "Not-for-profit bodies"
+                value: "basis-checkbox10",
+                text: "Not-for-profit bodies",
+                checked: savedValue === 'basis-checkbox10'
                 }
             ]
             }) }}

--- a/src/views/acquirer/basis.njk
+++ b/src/views/acquirer/basis.njk
@@ -31,52 +31,52 @@
                 {
                 value: "basis-checkbox1",
                 text: "Reasons of substantial public interest (with a basis in law)",
-                checked: savedValue === 'basis-checkbox1'
+                checked: (savedValue.includes('basis-checkbox1'))
                 },
                 {
                 value: "basis-checkbox2",
                 text: "Legal claims or judicial acts",
-                checked: savedValue === 'basis-checkbox2'
+                checked: (savedValue.includes('basis-checkbox2'))
                 },
                 {
                 value: "basis-checkbox3",
                 text: "Public health (with a basis in law)",
-                checked: savedValue === 'basis-checkbox3'
+                checked: (savedValue.includes('basis-checkbox3'))
                 },
                 {
                 value: "basis-checkbox4",
                 text: "Health or social care (with a basis in law)",
-                checked: savedValue === 'basis-checkbox4'
+                checked: (savedValue.includes('basis-checkbox4'))
                 },
                 {
                 value: "basis-checkbox5",
                 text: "Employment, social security and social protection (if authorised by law)",
-                checked: savedValue === 'basis-checkbox5'
+                checked: (savedValue.includes('basis-checkbox5'))
                 },
                 {
                 value: "basis-checkbox6",
                 text: "Vital interests",
-                checked: savedValue === 'basis-checkbox6'
+                checked: (savedValue.includes('basis-checkbox6'))
                 },
                 {
                 value: "basis-checkbox7",
                 text: "Explicit consent",
-                checked: savedValue === 'basis-checkbox7'
+                checked: (savedValue.includes('basis-checkbox7'))
                 },
                 {
                 value: "basis-checkbox8",
                 text: "Made public by the data subject",
-                checked: savedValue === 'basis-checkbox8'
+                checked: (savedValue.includes('basis-checkbox8'))
                 },
                 {
                 value: "basis-checkbox9",
                 text: "Archiving, research and statistics (with a basis in law)",
-                checked: savedValue === 'basis-checkbox9'
+                checked: (savedValue.includes('basis-checkbox9'))
                 },
                 {
                 value: "basis-checkbox10",
                 text: "Not-for-profit bodies",
-                checked: savedValue === 'basis-checkbox10'
+                checked: (savedValue.includes('basis-checkbox10'))
                 }
             ]
             }) }}

--- a/src/views/acquirer/basis.njk
+++ b/src/views/acquirer/basis.njk
@@ -1,0 +1,99 @@
+{% extends "page.njk" %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+      <form method="POST" id="dataAccessForm">
+        {% set basisHint %}
+        <p class="govuk-body">
+           Find out more about having a 
+           <a class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
+           <br>
+           You may need help from a data protection specialist.
+        </p>
+     {% endset %}
+            {{ govukCheckboxes({
+            name: "basis",
+            fieldset: {
+                legend: {
+                text: "What is your lawful basis for requesting special category data under UK GDPR?",
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l squish-hints"
+                }
+            },
+            hint: {
+                text: basisHint | safe
+            },
+            items: [
+                {
+                value: "checbox1",
+                text: "Reasons of substantial public interest (with a basis in law)"
+                },
+                {
+                value: "checbox2",
+                text: "Legal claims or judicial acts"
+                },
+                {
+                value: "checbox3",
+                text: "Public health (with a basis in law)"
+                },
+                {
+                value: "checbox4",
+                text: "Health or social care (with a basis in law)"
+                },
+                {
+                value: "checbox5",
+                text: "Employment, social security and social protection (if authorised by law)"
+                },
+                {
+                value: "checbox6",
+                text: "Vital interests"
+                },
+                {
+                value: "checbox7",
+                text: "Explicit consent"
+                },
+                {
+                value: "checbox8",
+                text: "Made public by the data subject"
+                },
+                {
+                value: "checbox9",
+                text: "Archiving, research and statistics (with a basis in law)"
+                },
+                {
+                value: "checbox10",
+                text: "Not-for-profit bodies"
+                }
+            ]
+            }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+                text: "Save and continue",
+                name: "continueButton",
+                value: "continue"
+            }) }}
+            {{ govukButton({
+                text: "Save and return",
+                classes: "govuk-button--secondary",
+                name: "returnButton",
+                value: "return"
+            }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+
+
+
+
+
+
+
+
+

--- a/src/views/acquirer/basis.njk
+++ b/src/views/acquirer/basis.njk
@@ -3,99 +3,99 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
-      <form method="POST" id="dataAccessForm">
-        {% set basisHint %}
-        <p class="govuk-body">
-           Find out more about having a 
-           <a class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
-           <br>
-           You may need help from a data protection specialist.
-        </p>
-     {% endset %}
-            {{ govukCheckboxes({
-            name: "basis",
-            fieldset: {
-                legend: {
-                text: "What is your lawful basis for requesting special category data under UK GDPR?",
-                isPageHeading: true,
-                classes: "govuk-fieldset__legend--l squish-hints"
-                }
-            },
-            hint: {
-                text: basisHint | safe
-            },
-            items: [
-                {
-                value: "basis-checkbox1",
-                text: "Reasons of substantial public interest (with a basis in law)",
-                checked: (savedValue.includes('basis-checkbox1'))
-                },
-                {
-                value: "basis-checkbox2",
-                text: "Legal claims or judicial acts",
-                checked: (savedValue.includes('basis-checkbox2'))
-                },
-                {
-                value: "basis-checkbox3",
-                text: "Public health (with a basis in law)",
-                checked: (savedValue.includes('basis-checkbox3'))
-                },
-                {
-                value: "basis-checkbox4",
-                text: "Health or social care (with a basis in law)",
-                checked: (savedValue.includes('basis-checkbox4'))
-                },
-                {
-                value: "basis-checkbox5",
-                text: "Employment, social security and social protection (if authorised by law)",
-                checked: (savedValue.includes('basis-checkbox5'))
-                },
-                {
-                value: "basis-checkbox6",
-                text: "Vital interests",
-                checked: (savedValue.includes('basis-checkbox6'))
-                },
-                {
-                value: "basis-checkbox7",
-                text: "Explicit consent",
-                checked: (savedValue.includes('basis-checkbox7'))
-                },
-                {
-                value: "basis-checkbox8",
-                text: "Made public by the data subject",
-                checked: (savedValue.includes('basis-checkbox8'))
-                },
-                {
-                value: "basis-checkbox9",
-                text: "Archiving, research and statistics (with a basis in law)",
-                checked: (savedValue.includes('basis-checkbox9'))
-                },
-                {
-                value: "basis-checkbox10",
-                text: "Not-for-profit bodies",
-                checked: (savedValue.includes('basis-checkbox10'))
-                }
-            ]
-            }) }}
-          <div class="govuk-button-group">
-            {{ govukButton({
-                text: "Save and continue",
-                name: "continueButton",
-                value: "continue"
-            }) }}
-            {{ govukButton({
-                text: "Save and return",
-                classes: "govuk-button--secondary",
-                name: "returnButton",
-                value: "return"
-            }) }}
-        </div>
-      </form>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+    <form method="POST" id="dataAccessForm">
+      {% set basisHint %}
+      <p class="govuk-body">
+          Find out more about having a 
+          <a class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
+          <br>
+          You may need help from a data protection specialist.
+      </p>
+      {% endset %}
+      {{ govukCheckboxes({
+      name: "basis",
+      fieldset: {
+          legend: {
+          text: "What is your lawful basis for requesting special category data under UK GDPR?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l squish-hints"
+          }
+      },
+      hint: {
+          text: basisHint | safe
+      },
+      items: [
+          {
+          value: "basis-checkbox1",
+          text: "Reasons of substantial public interest (with a basis in law)",
+          checked: (savedValue.includes('basis-checkbox1'))
+          },
+          {
+          value: "basis-checkbox2",
+          text: "Legal claims or judicial acts",
+          checked: (savedValue.includes('basis-checkbox2'))
+          },
+          {
+          value: "basis-checkbox3",
+          text: "Public health (with a basis in law)",
+          checked: (savedValue.includes('basis-checkbox3'))
+          },
+          {
+          value: "basis-checkbox4",
+          text: "Health or social care (with a basis in law)",
+          checked: (savedValue.includes('basis-checkbox4'))
+          },
+          {
+          value: "basis-checkbox5",
+          text: "Employment, social security and social protection (if authorised by law)",
+          checked: (savedValue.includes('basis-checkbox5'))
+          },
+          {
+          value: "basis-checkbox6",
+          text: "Vital interests",
+          checked: (savedValue.includes('basis-checkbox6'))
+          },
+          {
+          value: "basis-checkbox7",
+          text: "Explicit consent",
+          checked: (savedValue.includes('basis-checkbox7'))
+          },
+          {
+          value: "basis-checkbox8",
+          text: "Made public by the data subject",
+          checked: (savedValue.includes('basis-checkbox8'))
+          },
+          {
+          value: "basis-checkbox9",
+          text: "Archiving, research and statistics (with a basis in law)",
+          checked: (savedValue.includes('basis-checkbox9'))
+          },
+          {
+          value: "basis-checkbox10",
+          text: "Not-for-profit bodies",
+          checked: (savedValue.includes('basis-checkbox10'))
+          }
+      ]
+      }) }}
+      <div class="govuk-button-group">
+      {{ govukButton({
+          text: "Save and continue",
+          name: "continueButton",
+          value: "continue"
+      }) }}
+      {{ govukButton({
+          text: "Save and return",
+          classes: "govuk-button--secondary",
+          name: "returnButton",
+          value: "return"
+      }) }}
+      </div>
+    </form>
   </div>
+</div>
 {% endblock %}
 
 

--- a/src/views/acquirer/lawful-basis-personal.njk
+++ b/src/views/acquirer/lawful-basis-personal.njk
@@ -19,7 +19,7 @@
       name: "lawful-basis-personal",
       fieldset: {
           legend: {
-          text: "What is your lawful basis for requesting special category data under UK GDPR?",
+          text: "What is your lawful basis for requesting personal category data under UK GDPR?",
           isPageHeading: true,
           classes: "govuk-fieldset__legend--l squish-hints"
           }

--- a/src/views/acquirer/lawful-basis-personal.njk
+++ b/src/views/acquirer/lawful-basis-personal.njk
@@ -1,0 +1,105 @@
+{% extends "page.njk" %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+      <form method="POST" id="dataAccessForm">
+        {% set basisHint %}
+        <p class="govuk-body">
+          Find out more about having a 
+          <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
+          <br>
+          You may need help from a data protection specialist.
+      </p>
+        {% endset %}
+        {{ govukCheckboxes({
+      name: "lawful-basis-personal",
+      fieldset: {
+          legend: {
+          text: "What is your lawful basis for requesting special category data under UK GDPR?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l squish-hints"
+          }
+      },
+      hint: {
+          html: basisHint
+      },
+      items: [
+          {
+          value: "public-task",
+          text: "Public Task",
+          checked: savedValue["public-task"].checked,
+          hint: {
+            text: "The processing is necessary for you to perform a task in the public interest or for your official functions, and the task or function has a clear basis in law."
+          }
+          },
+          {
+          value: "legal-obligation",
+          text: "Legal obligation",
+          checked: savedValue["legal-obligation"].checked,
+          hint: {
+            text: "The processing is necessary for the Controller to comply with the law (not including contractual obligations)."
+          }
+          },
+          {
+          value: "contract",
+          text: "Contract",
+          checked: savedValue["contract"].checked,
+          hint: {
+            text: "The processing is necessary for a contract the Controller has with the individual, or because they have asked you to take specific steps before entering into a contract."
+          }
+          },
+          {
+          value: "legitimate-interests",
+          text: "Legitimate interests",
+          checked: savedValue["legitimate-interests"].checked,
+          hint: {
+            text: "The processing is necessary for your legitimate interests or the legitimate interests of a third party unless there is a good reason to protect the individual’s personal data which overrides those legitimate interests."
+          }
+          },
+          {
+          value: "consent",
+          text: "Consent",
+          checked: savedValue["consent"].checked,
+          hint: {
+            text: "The individual has given clear consent for you to process their personal data for a specific purpose."
+          }
+          },
+          {
+          value: "vital-interest",
+          text: "Vital interests",
+          checked: savedValue["vital-interest"].checked,
+          hint: {
+            text: "The processing is necessary to protect someone’s life."
+          }
+          },
+          {
+          value: "law-enforcement",
+          text: "Law enforcement",
+          checked: savedValue["law-enforcement"].checked,
+          hint: {
+            text: "The data processing is under Part 3 DPA18 and either by consent or is necessary for the performance of a task carried out for that purpose by a competent authority"
+          }
+        }
+      ]
+      }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+          text: "Save and continue",
+          name: "continueButton",
+          value: "continue"
+      }) }}
+          {{ govukButton({
+          text: "Save and return",
+          classes: "govuk-button--secondary",
+          name: "returnButton",
+          value: "return"
+      }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/views/acquirer/lawful-basis-personal.njk
+++ b/src/views/acquirer/lawful-basis-personal.njk
@@ -8,12 +8,12 @@
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="dataAccessForm">
         {% set basisHint %}
-        <p class="govuk-body">
-          Find out more about having a 
-          <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
-          <br>
-          You may need help from a data protection specialist.
-      </p>
+        <div>
+          <p class="govuk-body">Find out more about having a 
+            <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">
+            lawful basis for processing personal data (opens in new tab).</a>
+          <p class="govuk-body">You may need help from a data protection specialist.</p>
+        </div>
         {% endset %}
         {{ govukCheckboxes({
       name: "lawful-basis-personal",

--- a/src/views/acquirer/lawful-basis-special.njk
+++ b/src/views/acquirer/lawful-basis-special.njk
@@ -29,54 +29,54 @@
       },
       items: [
           {
-          value: "basis-checkbox1",
+          value: "reasons-of-public-interest",
           text: "Reasons of substantial public interest (with a basis in law)",
-          checked: (savedValue.includes('basis-checkbox1'))
+          checked: savedValue["reasons-of-public-interest"].checked
           },
           {
-          value: "basis-checkbox2",
+          value: "legal-claim-or-judicial-acts",
           text: "Legal claims or judicial acts",
-          checked: (savedValue.includes('basis-checkbox2'))
+          checked: savedValue["legal-claim-or-judicial-acts"].checked
           },
           {
-          value: "basis-checkbox3",
+          value: "public-health",
           text: "Public health (with a basis in law)",
-          checked: (savedValue.includes('basis-checkbox3'))
+          checked: savedValue["public-health"].checked
           },
           {
-          value: "basis-checkbox4",
+          value: "health-or-social-care",
           text: "Health or social care (with a basis in law)",
-          checked: (savedValue.includes('basis-checkbox4'))
+          checked: savedValue["health-or-social-care"].checked
           },
           {
-          value: "basis-checkbox5",
+          value: "social-employment-security-and-protection",
           text: "Employment, social security and social protection (if authorised by law)",
-          checked: (savedValue.includes('basis-checkbox5'))
+          checked: savedValue["social-employment-security-and-protection"].checked
           },
           {
-          value: "basis-checkbox6",
+          value: "vital-interests",
           text: "Vital interests",
-          checked: (savedValue.includes('basis-checkbox6'))
+          checked: savedValue["vital-interests"].checked
           },
           {
-          value: "basis-checkbox7",
+          value: "explicit-consent",
           text: "Explicit consent",
-          checked: (savedValue.includes('basis-checkbox7'))
+          checked: savedValue["explicit-consent"].checked
           },
           {
-          value: "basis-checkbox8",
+          value: "public-by-data-subject",
           text: "Made public by the data subject",
-          checked: (savedValue.includes('basis-checkbox8'))
+          checked: savedValue["public-by-data-subject"].checked
           },
           {
-          value: "basis-checkbox9",
+          value: "archiving-researching-statistics",
           text: "Archiving, research and statistics (with a basis in law)",
-          checked: (savedValue.includes('basis-checkbox9'))
+          checked: savedValue["archiving-researching-statistics"].checked
           },
           {
-          value: "basis-checkbox10",
+          value: "not-for-profit-bodies",
           text: "Not-for-profit bodies",
-          checked: (savedValue.includes('basis-checkbox10'))
+          checked: savedValue["not-for-profit-bodies"].checked
           }
       ]
       }) }}

--- a/src/views/acquirer/lawful-basis-special.njk
+++ b/src/views/acquirer/lawful-basis-special.njk
@@ -10,7 +10,7 @@
         {% set basisHint %}
         <p class="govuk-body">
           Find out more about having a 
-          <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing personal data (opens in new tab).</a>
+          <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing special data (opens in new tab).</a>
           <br>
           You may need help from a data protection specialist.
       </p>

--- a/src/views/acquirer/lawful-basis-special.njk
+++ b/src/views/acquirer/lawful-basis-special.njk
@@ -2,18 +2,19 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+ 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="dataAccessForm">
         {% set basisHint %}
-        <p class="govuk-body">
-          Find out more about having a 
-          <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">lawful basis for processing special data (opens in new tab).</a>
-          <br>
-          You may need help from a data protection specialist.
-      </p>
+        <div>
+          <p class="govuk-body">Find out more about having a 
+            <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">
+            lawful basis for processing special category data (opens in new tab).</a>
+          <p class="govuk-body">You may need help from a data protection specialist.</p>
+        </div>
         {% endset %}
         {{ govukCheckboxes({
       name: "lawful-basis-special",

--- a/src/views/acquirer/legal-gateway.njk
+++ b/src/views/acquirer/legal-gateway.njk
@@ -12,37 +12,37 @@
         
         {% set legalGatewayDecision1 %}
         {{ govukTextarea({
-            id: "yes-decision",
-            name: "yes-decision",
+            id: "yes",
+            name: "yes",
             type: "text",
             classes: "govuk-!-width-two-third",
             label: {
                 text: "What is the legal gateway for acquiring this data?"
             },
-            value: savedValue['yes-decision']['explanation']
+            value: savedValue['yes']['explanation']
         }) }}
         {% endset -%}
 
         {% set legalGatewayDecision2 %}
         {{ govukTextarea({
-            id: "other-decision",
-            name: "other-decision",
+            id: "other",
+            name: "other",
             type: "text",
             classes: "govuk-!-width-two-third",
             label: {
                 text: "What other legal grounds do you have for acquiring this data?"
             },
-            value: savedValue['other-decision']['explanation']
+            value: savedValue['other']['explanation']
         }) }}
         {% endset -%}
 
         {% set legalGatewayDecision3 %}
         {{ govukTextarea({
-            id: "dont-know-decision",
-            name: "dont-know-decision",
+            id: "we-dont-know",
+            name: "we-dont-know",
             type: "text",
             classes: "govuk-!-width-two-third",
-            value: savedValue['dont-know-decision']['explanation']
+            value: savedValue['we-dont-know']['explanation']
         }) }}
         {% endset -%}
 
@@ -60,25 +60,25 @@
         },
         items: [
             {
-            value: "yes-decision",
+            value: "yes",
             text: "Yes, there is a legal gateway for acquiring this data",
-            checked: savedValue['yes-decision']['checked'],
+            checked: savedValue['yes']['checked'],
             conditional: {
                 html: legalGatewayDecision1
             }
             },
             {
-            value: "other-decision",
+            value: "other",
             text: "We have other legal grounds for acquiring this data",
-            checked: savedValue['other-decision']['checked'],
+            checked: savedValue['other']['checked'],
             conditional: {
                 html: legalGatewayDecision2
             }
             },
             {
-            value: "dont-know-decision",
+            value: "we-dont-know",
             text: "We don't know",
-            checked: savedValue['dont-know-decision']['checked'],
+            checked: savedValue['we-dont-know']['checked'],
             conditional: {
                 html: textHtml
             }

--- a/src/views/acquirer/legal-power.njk
+++ b/src/views/acquirer/legal-power.njk
@@ -15,7 +15,7 @@
                 label: {
                     text: "What legal power will you use?"
                 },
-                value: savedValue.explanation
+                value: savedValue['yes']['explanation']
             }) }}
         {% endset -%}
         {{ govukRadios({
@@ -35,8 +35,7 @@
             {
                 value: "yes",
                 text: "Yes, we believe we have the legal power to do this",
-                checked: savedValue.decision === 'yes',
-
+                checked: savedValue['yes']['checked'],
                 conditional: {
                     html: legalPowerDecision
                 }
@@ -44,12 +43,12 @@
             {
                 value: "no",
                 text: "No, we don't have the legal power to request this",
-                checked: savedValue.decision === "no"
+                checked: savedValue['no']['checked']
             },
             {
-                value: "we don't know",
+                value: "we-dont-know",
                 text: "We don't know",
-                checked: savedValue.decision === "we don't know"
+                checked: savedValue['we-dont-know']['checked']
             }
             ]
           }) 


### PR DESCRIPTION
## DMBM-707 Changes

- Implemented Data Protection - Basis page
- updated shareRequestTemplate json - basis to have value: [] to allow for multiple checkbox values

Implemented the Lawful Basis Personal and Special page

Implemented type guarding for the existing pages, all of this is done in the extractFormData function.

I have abstracted out the ```  const radioFields = ["data-type", "data-access", "legal-review"];
  const textFields = ["impact", "data-subjects", "data-required"];``` into its own type:

  ```
type TextFieldStepID = "impact" | "data-subjects" | "data-required";
    and
type RadioFieldStepID = "data-type" | "data-access" | "legal-review";
```

It's important to note that the step interface here:

```
interface Step {
  id: TextFieldStepID | RadioFieldStepID |
  name: string;
  status: string;
  value: StepValue;
  nextStep?: string;
  blockedBy?: string[];
  errorMessage?: string;
  skipped?: boolean;
}
```

I have also refactored the legal-power page:
from:
```
{
    value: "we don't know",
    text: "We don't know",
    checked: savedValue.decision === "we don't know"
}
```
to:
```
 {
    value: "we-dont-know",
    text: "We don't know",
    checked: savedValue['we-dont-know']['checked']
}
```

with this change, ive created the new types here:

```
type LegalDecision = {
  explanation?: string;
  checked: boolean;
};

type LegalPowerStep = {
  yes: LegalDecision;
  no: LegalDecision;
  "we-dont-know": LegalDecision;
};

type LegalGatewayStep = {
  yes: LegalDecision;
  other: LegalDecision;
  "we-dont-know": LegalDecision;
};
```
I have also made changes to the Legal-gateway page as the chosen string id's didnt match a clean aspect, so i have changed:

```id: "other-decision" to id: "other" ...etc```

