### PR TITLE
Legal Advice Pages

### DIFF
--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -7,7 +7,8 @@ import {
   extractFormData,
   validateRequestBody,
 } from "../helperFunctions/helperFunctions";
-import { FormData } from "../types/express";
+import { FormData, LegalGatewayStep, LegalPowerStep } from "../types/express";
+
 function parseJwt(token: string) {
   return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
 }
@@ -41,6 +42,16 @@ const skipThisStep = (step: string, formdata: FormData) => {
     case "other-orgs": {
       // Skip other-orgs if the answer to data-access was "no"
       return formdata.steps["data-access"].value === "no";
+    }
+    case "legal-power-advice": {
+      // Skip legal-power-advice if the answer to legal-power was "Yes"
+      const legalPowerStep = formdata.steps["legal-power"].value as LegalPowerStep
+      return legalPowerStep.yes.checked
+    }
+    case "legal-gateway-advice": {
+      // Skip legal-gateway-advice if the answer to legal-gateway was "yes" or "other"
+      const legalGatewayStep = formdata.steps["legal-gateway"].value as LegalGatewayStep
+      return legalGatewayStep.yes.checked || legalGatewayStep.other.checked
     }
     default: {
       return false;

--- a/src/views/acquirer/legal-gateway-advice.njk
+++ b/src/views/acquirer/legal-gateway-advice.njk
@@ -8,20 +8,24 @@
       <h1 class="govuk-heading-l">Get legal advice</h1>
       <p class="govuk-body">Contact a lawyer, or someone with legal expertise, to discuss your legal power for requesting data.</p>
       <p class="govuk-body">Once you've provided your legal power, return to this service and continue.</p>
-      <p class="govuk-body"><a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-sharing/data-sharing-a-code-of-practice/lawfulness/" class="govuk-link">See guidance on lawfulness from the Information Commissioner's Office (opens in new tab)</a></p>
-      <div class="govuk-button-group">
-            {{ govukButton({
+      <p class="govuk-body">
+        <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-sharing/data-sharing-a-code-of-practice/lawfulness/" class="govuk-link">See guidance on lawfulness from the Information Commissioner's Office (opens in new tab)</a>
+      </p>
+      <form method="POST" id="dataTypeForm">
+        <div class="govuk-button-group">
+          {{ govukButton({
                 text: "Save and continue",
                 name: "continueButton",
                 value: "continue"
             }) }}
-            {{ govukButton({
+          {{ govukButton({
                 text: "Save and return",
                 classes: "govuk-button--secondary",
                 name: "returnButton",
                 value: "return"
             }) }}
         </div>
+      </form>
     </div>
   </div>
-{%endblock%}
+  {%endblock%}

--- a/src/views/acquirer/legal-gateway-advice.njk
+++ b/src/views/acquirer/legal-gateway-advice.njk
@@ -11,7 +11,7 @@
       <p class="govuk-body">
         <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-sharing/data-sharing-a-code-of-practice/lawfulness/" class="govuk-link">See guidance on lawfulness from the Information Commissioner's Office (opens in new tab)</a>
       </p>
-      <form method="POST" id="dataTypeForm">
+      <form method="POST" id="legalGatewayAdviceForm">
         <div class="govuk-button-group">
           {{ govukButton({
                 text: "Save and continue",

--- a/src/views/acquirer/legal-power-advice.njk
+++ b/src/views/acquirer/legal-power-advice.njk
@@ -11,7 +11,7 @@
       <p class="govuk-body">
         <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-sharing/data-sharing-a-code-of-practice/lawfulness/" class="govuk-link">See guidance on lawfulness from the Information Commissioner's Office (opens in new tab)</a>
       </p>
-      <form method="POST" id="dataTypeForm">
+      <form method="POST" id="legalPowerAdviceForm">
         <div class="govuk-button-group">
           {{ govukButton({
                 text: "Save and continue",

--- a/src/views/acquirer/legal-power-advice.njk
+++ b/src/views/acquirer/legal-power-advice.njk
@@ -1,0 +1,31 @@
+{% extends "page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+      <h1 class="govuk-heading-l">Get legal advice</h1>
+      <p class="govuk-body">Contact a lawyer, or someone with legal expertise, to discuss your legal power for requesting data.</p>
+      <p class="govuk-body">Once you've provided your legal power, return to this service and continue.</p>
+      <p class="govuk-body">
+        <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-sharing/data-sharing-a-code-of-practice/lawfulness/" class="govuk-link">See guidance on lawfulness from the Information Commissioner's Office (opens in new tab)</a>
+      </p>
+      <form method="POST" id="dataTypeForm">
+        <div class="govuk-button-group">
+          {{ govukButton({
+                text: "Save and continue",
+                name: "continueButton",
+                value: "continue"
+            }) }}
+          {{ govukButton({
+                text: "Save and return",
+                classes: "govuk-button--secondary",
+                name: "returnButton",
+                value: "return"
+            }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+  {%endblock%}


### PR DESCRIPTION
# Changes
- Added legal-power-advice and lega-gateway-advice pages, and the steps in `skipThisStep` to skip over them if necessary.

The [determineNextStep](https://github.com/co-cddo/data-marketplace/blob/DMBM/Legalpowerandgateway_HiddenLegalAdvice/src/routes/acquirerRoutes.ts#L51) function in @AShaww 's branch is another way of doing this.

`determineThisStep` is definitely more flexible, in that it would let you jump from one page of the form to any other. But I don't think we need that flexibility at the moment, and it'd be a pretty complicated form for the users if they were expected to complete it not in start->finish order (it's already pretty complicated with all the hidden pages, but I don't think there are any plans to completely change the flow)