### PR TITLE
Data-type page now uses checkboxes

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -150,21 +150,22 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   }
 
   if (stepData.id === "data-type") {
-    console.log(stepData, body)
+    const isNoneChecked = body["data-type"]?.includes("none");
+    const isPersonalChecked = !isNoneChecked && body["data-type"]?.includes("personal");
+    const isSpecialChecked = !isNoneChecked && body["data-type"]?.includes("special");
+
     return {
       "personal": {
-        checked: body["data-type"]?.includes("personal"),
+        checked: isPersonalChecked,
       },
       "special": {
-        checked: body["data-type"]?.includes("special"),
+        checked: isSpecialChecked,
       },
       "none": {
-        explanation: body["none"],
-        checked: body["data-type"]?.includes("none"),
+        checked: isNoneChecked,
       },
     } as DataTypeStep;
   }
-
 
   if (stepData.id === "project-aims") {
     return {

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -1,5 +1,6 @@
 import { licences } from "../mockData/licences";
 import {
+  DataTypeStep,
   BenefitsStep,
   DateStep,
   FormatStep,
@@ -124,7 +125,7 @@ const validateRequestBody = (step: string, body: RequestBody): string => {
 };
 
 function isRadioField(id: string): id is RadioFieldStepID {
-  return ["data-type", "data-access", "legal-review", "role"].includes(id);
+  return ["data-access", "legal-review", "role"].includes(id);
 }
 
 function isTextField(id: string): id is TextFieldStepID {
@@ -147,6 +148,23 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   if (isTextField(stepData.id)) {
     return body[stepData.id] as StepValue;
   }
+
+  if (stepData.id === "data-type") {
+    console.log(stepData, body)
+    return {
+      "personal": {
+        checked: body["data-type"]?.includes("personal"),
+      },
+      "special": {
+        checked: body["data-type"]?.includes("special"),
+      },
+      "none": {
+        explanation: body["none"],
+        checked: body["data-type"]?.includes("none"),
+      },
+    } as DataTypeStep;
+  }
+
 
   if (stepData.id === "project-aims") {
     return {

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -46,7 +46,7 @@
       "id": "data-type",
       "name": "Data type",
       "status": "NOT STARTED",
-      "value": "",
+      "value": [],
       "nextStep": "data-subjects"
     },
     "data-subjects": {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -23,7 +23,7 @@ export interface RequestBody {
 
 // Add id's here. Should only be able to handle single value
 type TextFieldStepID = "impact" | "data-subjects" | "data-required" | "disposal";
-type RadioFieldStepID = "data-type" | "data-access" | "legal-review" | "role";
+type RadioFieldStepID = "data-access" | "legal-review" | "role";
 
 interface Benefits {
   explanation?: string;
@@ -42,38 +42,44 @@ type BenefitsStep = {
   "something-else"?: Benefits;
 };
 
+type DataTypeStep = {
+  personal: GenericDecisions;
+  special: GenericDecisions;
+  none: GenericDecisions;
+}
+
 type ProjectAimStep = {
   aims: string;
   explanation: string;
 };
 
-type LegalDecision = {
+type GenericDecisions = {
   explanation?: string;
   checked: boolean;
 };
 
 type DeliveryStep = {
-  "third-party": LegalDecision;
-  physical: LegalDecision;
-  something: LegalDecision
+  "third-party": GenericDecisions;
+  physical: GenericDecisions;
+  something: GenericDecisions
 }
 
 type FormatStep = {
-  csv: LegalDecision;
-  sql: LegalDecision;
-  something: LegalDecision;
+  csv: GenericDecisions;
+  sql: GenericDecisions;
+  something: GenericDecisions;
 };
 
 type LegalPowerStep = {
-  yes: LegalDecision;
-  no: LegalDecision;
-  "we-dont-know": LegalDecision;
+  yes: GenericDecisions;
+  no: GenericDecisions;
+  "we-dont-know": GenericDecisions;
 };
 
 type LegalGatewayStep = {
-  yes: LegalDecision;
-  other: LegalDecision;
-  "we-dont-know": LegalDecision;
+  yes: GenericDecisions;
+  other: GenericDecisions;
+  "we-dont-know": GenericDecisions;
 };
 
 interface LawfulBasis {
@@ -105,6 +111,7 @@ type LawfulBasisSpecialStep = {
 
 export type StepValue =
   | string
+  | DataTypeStep
   | ProjectAimStep
   | BenefitsStep
   | LegalPowerStep

--- a/src/views/acquirer/data-type.njk
+++ b/src/views/acquirer/data-type.njk
@@ -1,5 +1,5 @@
 {% extends "page.njk" %}
-{%- from "govuk/components/radios/macro.njk" import govukRadios -%}
+{%- from "govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="dataTypeForm">
-        {{ govukRadios({
+        {{ govukCheckboxes({
                   name: "data-type",
                   fieldset: {
                       legend: {
@@ -20,7 +20,7 @@
                       {
                       value: "personal",
                       text: "Personal data",
-                      checked: savedValue === 'personal',
+                      checked: savedValue["personal"].checked,
                       hint: {
                           text: "For example, names or addresses."
                       }
@@ -28,7 +28,7 @@
                       {
                       value: "special",
                       text: "Special category data",
-                      checked: savedValue === 'special',
+                      checked: savedValue["special"].checked,
                       hint: {
                           text: "For example, data about health or religious beliefs."
                       }
@@ -39,7 +39,7 @@
                       {
                       value: "none",
                       text: "None of the above",
-                      checked: savedValue === 'none',
+                      checked: savedValue["none"].checked,
                       hint: {
                           text: "For example, anonymised data."
                       }


### PR DESCRIPTION
Made it so the data-type page uses checkboxes, so we can have multiple values for the skipping pages within the Data Protection section, see here:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/eff8db99-f975-4286-a408-d1729f04b86c)


I have gone and implemented a DataTypeStep type - with this i have updated the LegalDecision type to GenericDecisions
see here:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/3b8597ec-6293-45ab-9f12-ca6a1957beb3)
and here:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/2063fcb3-2b59-4f0e-ab72-fc7d144e74d8)


The changes were made to help blockers on routing within the DataProtection section of the acquirer journey