### PR TITLE
Data type behaviour bug fix

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -150,19 +150,15 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   }
 
   if (stepData.id === "data-type") {
-    const isNoneChecked = body["data-type"]?.includes("none");
-    const isPersonalChecked = !isNoneChecked && body["data-type"]?.includes("personal");
-    const isSpecialChecked = !isNoneChecked && body["data-type"]?.includes("special");
-
     return {
       "personal": {
-        checked: isPersonalChecked,
+        checked: body["data-type"]?.includes("personal"),
       },
       "special": {
-        checked: isSpecialChecked,
+        checked: body["data-type"]?.includes("special"),
       },
       "none": {
-        checked: isNoneChecked,
+        checked: body["data-type"]?.includes("none"),
       },
     } as DataTypeStep;
   }

--- a/src/views/acquirer/data-type.njk
+++ b/src/views/acquirer/data-type.njk
@@ -42,7 +42,8 @@
                       checked: savedValue["none"].checked,
                       hint: {
                           text: "For example, anonymised data."
-                      }
+                      },
+                      behaviour: "exclusive"
                       }
                   ]
                   }) }}


### PR DESCRIPTION
Added exclusive behaviour to data-type "none" checkbox, this makes it so selecting "none" clears "personal" and "special" if selected.

Also refactored data-type case in extractFormData, we don't need to check inputs anymore