### PR TITLE
Dmbm 779/dataprotectionlawfulbasis_specialcategorydata

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -6,6 +6,7 @@ import {
   FormatStep,
   LawfulBasisPersonalStep,
   LawfulBasisSpecialStep,
+  LawfulSpecialPublicInterestStep,
   LegalGatewayStep,
   LegalPowerStep,
   ProjectAimStep,
@@ -14,7 +15,8 @@ import {
   StepValue,
   RadioFieldStepID,
   TextFieldStepID,
-  DeliveryStep
+  DeliveryStep,
+ 
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -363,6 +365,112 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
     } as LawfulBasisSpecialStep;
   }
 
+  if (stepData.id === "lawful-basis-special-public-interest") {
+    return {
+      "statutory-government-purposes": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "statutory-government-purposes",
+        ),
+      },
+      "administration-justice-parliamentary-purposes": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "administration-justice-parliamentary-purposes",
+        ),
+      },
+      "equality-opportunity-or-treatment": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "equality-opportunity-or-treatment",
+        ),
+      },
+      "preventing-or-detecting-unlawful-acts": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "preventing-or-detecting-unlawful-acts",
+        ),
+      },
+      "protecting-the-public": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("protecting-the-public"),
+      },
+      "racial-ethnic-diversity-senior-levels": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "racial-ethnic-diversity-senior-levels",
+        ),
+      },
+      "regulatory-requirements": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "regulatory-requirements",
+        ),
+      },
+      "journalism-academia-art-literature": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "journalism-academia-art-literature",
+        ),
+      },
+      "preventing-fraud": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("preventing-fraud"),
+      },
+      "suspicion-terrorist-financing-or-money-laundering": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "suspicion-terrorist-financing-or-money-laundering",
+        ),
+      },
+      "support-particular-disability-or-mental-condition": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "support-particular-disability-or-mental-condition",
+        ),
+      },
+      "counselling": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("counselling"),
+      },
+      "safeguarding-children-individuals-risk": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "safeguarding-children-individuals-risk",
+        ),
+      },
+      "safeguarding-economic-well-being": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "safeguarding-economic-well-being",
+        ),
+      },
+      "insurance": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("insurance"),
+      },
+      "occupational-pensions": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("occupational-pensions"),
+      },
+      "political-parties": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("political-parties"),
+      },
+      "elected-representatives-responding-requests": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "elected-representatives-responding-requests",
+        ),
+      },
+      "disclosure-elected-representatives": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "disclosure-elected-representatives",
+        ),
+      },
+      "informing-elected-representatives-about-prisoners": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "informing-elected-representatives-about-prisoners",
+        ),
+      },
+      "publication-legal-judgments": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "publication-legal-judgments",
+        ),
+      },
+      "anti-doping-sport": {
+        checked: body["lawful-basis-special-public-interest"]?.includes("anti-doping-sport"),
+      },
+      "standards-behaviour-sport": {
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "standards-behaviour-sport",
+        ),
+      },
+    } as LawfulSpecialPublicInterestStep;
+  }
+  
   // Other input types can go here
   return "";
 };

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,7 +16,6 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
- 
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -127,11 +126,23 @@ const validateRequestBody = (step: string, body: RequestBody): string => {
 };
 
 function isRadioField(id: string): id is RadioFieldStepID {
-  return ["data-access", "legal-review", "role", "data-travel", "protection-review"].includes(id);
+  return [
+    "data-access",
+    "legal-review",
+    "role",
+    "data-travel",
+    "protection-review",
+  ].includes(id);
 }
 
 function isTextField(id: string): id is TextFieldStepID {
-  return ["impact", "data-subjects", "data-required", "disposal", "data-travel-location"].includes(id);
+  return [
+    "impact",
+    "data-subjects",
+    "data-required",
+    "disposal",
+    "data-travel-location",
+  ].includes(id);
 }
 
 const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
@@ -153,13 +164,13 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
 
   if (stepData.id === "data-type") {
     return {
-      "personal": {
+      personal: {
         checked: body["data-type"]?.includes("personal"),
       },
-      "special": {
+      special: {
         checked: body["data-type"]?.includes("special"),
       },
-      "none": {
+      none: {
         checked: body["data-type"]?.includes("none"),
       },
     } as DataTypeStep;
@@ -254,22 +265,23 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
     } as LegalGatewayStep;
   }
 
-  if(stepData.id === "delivery") {
-   return {
-    "third-party": {
-      checked: body["delivery"] === "third-party",
-    },
-    physical: {
-      checked: body["delivery"] === "physical",
-    },
-    something: {
-      checked: body["delivery"] === "something",
-      explanation: body["delivery"] === "something" ? body["something-else"] : "",
-    }
-   }   as DeliveryStep;
-  };
+  if (stepData.id === "delivery") {
+    return {
+      "third-party": {
+        checked: body["delivery"] === "third-party",
+      },
+      physical: {
+        checked: body["delivery"] === "physical",
+      },
+      something: {
+        checked: body["delivery"] === "something",
+        explanation:
+          body["delivery"] === "something" ? body["something-else"] : "",
+      },
+    } as DeliveryStep;
+  }
 
-  if(stepData.id === "format") {
+  if (stepData.id === "format") {
     return {
       csv: {
         checked: body["format"] === "csv",
@@ -279,11 +291,12 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
       },
       something: {
         checked: body["format"] === "something",
-        explanation: body["format"] === "something" ? body["something-else"] : "",
-    }   
-   } as FormatStep;
+        explanation:
+          body["format"] === "something" ? body["something-else"] : "",
+      },
+    } as FormatStep;
   }
-  
+
   if (stepData.id === "lawful-basis-personal") {
     return {
       "public-task": {
@@ -364,17 +377,18 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   if (stepData.id === "lawful-basis-special-public-interest") {
     return {
       statutory: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "statutory",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("statutory"),
       },
       administration: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "administration",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes(
+            "administration",
+          ),
       },
       equality: {
-        checked: body["lawful-basis-special-public-interest"]?.includes("equality"),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("equality"),
       },
       "preventing-detecting": {
         checked: body["lawful-basis-special-public-interest"]?.includes(
@@ -382,47 +396,50 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
         ),
       },
       protecting: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "protecting",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("protecting"),
       },
       "regulatory-requirements": {
-        checked: body["lawful-basis-special-public-interest"]?.includes("regulatory-requirements"),
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "regulatory-requirements",
+        ),
       },
       journalism: {
-        checked: body["lawful-basis-special-public-interest"]?.includes("journalism"),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("journalism"),
       },
       "preventing-fraud": {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "preventing-fraud",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes(
+            "preventing-fraud",
+          ),
       },
       suspicion: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "suspicion",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("suspicion"),
       },
       support: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "support",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("support"),
       },
 
       counselling: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "counselling",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("counselling"),
       },
       "safeguarding-children": {
-        checked: body["lawful-basis-special-public-interest"]?.includes("safeguarding-children"),
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "safeguarding-children",
+        ),
       },
       "safeguarding-economic": {
-        checked: body["lawful-basis-special-public-interest"]?.includes("safeguarding-economic"),
+        checked: body["lawful-basis-special-public-interest"]?.includes(
+          "safeguarding-economic",
+        ),
       },
       insurance: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "insurance",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("insurance"),
       },
       "occupational-pensions": {
         checked: body["lawful-basis-special-public-interest"]?.includes(
@@ -430,35 +447,36 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
         ),
       },
       "political-parties": {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "political-parties",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes(
+            "political-parties",
+          ),
       },
       elected: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "elected",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("elected"),
       },
       disclosure: {
-        checked: body["lawful-basis-special-public-interest"]?.includes("disclosure"),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("disclosure"),
       },
       informing: {
-        checked: body["lawful-basis-special-public-interest"]?.includes("informing"),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("informing"),
       },
       "legal-judgments": {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "legal-judgments",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes(
+            "legal-judgments",
+          ),
       },
       "anti-doping": {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "anti-doping",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("anti-doping"),
       },
       standards: {
-        checked: body["lawful-basis-special-public-interest"]?.includes(
-          "standards",
-        ),
+        checked:
+          body["lawful-basis-special-public-interest"]?.includes("standards"),
       },
     } as LawfulBasisSpecialPublicInterestStep;
   }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -54,16 +54,6 @@ const skipThisStep = (step: string, formdata: FormData) => {
       const legalGatewayStep = formdata.steps["legal-gateway"].value as LegalGatewayStep
       return legalGatewayStep.yes.checked || legalGatewayStep.other.checked
     }
-    case "lawful-basis-personal": {
-      // Skip lawful-basis-personal if answer to data-type was "special" or "none"
-      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
-      return DataTypeStep.special.checked || DataTypeStep.none.checked
-    }
-    case "lawful-basis-special": {
-      // Skip lawful-basis-special if answer to data-type was "personal" or "none"
-      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
-      return DataTypeStep.personal.checked || DataTypeStep.none.checked
-    }
     case "role": {
       const data = formdata.steps["data-type"].value as DataTypeStep
       return (data.none.checked || (data.personal.checked === undefined && data.special.checked === undefined))
@@ -158,9 +148,9 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   // If current step is 'data-type', set the back link to start page -> 
   // in preperation for Maddies current work before Annual leave data-type being the only page to start from
   backLink = `/acquirer/${resourceID}/start`;
-} else if (formdata.stepHistory && formdata.stepHistory.length > 1) {
+} else if (formdata.stepHistory && formdata.stepHistory.length > 0) {
   // Otherwise, set it to the previous step from stepHistory
-  backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 2]}?action=back`;
+  backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 1]}?action=back`;
 }
 
   res.render(`../views/acquirer/${formStep}.njk`, {

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -162,12 +162,6 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
-  // If we have history and are pressing back, we set the back link.
-  if (formdata.stepHistory.length > 1) {
-    backLink = `/acquirer/${resourceID}/${
-      formdata.stepHistory[formdata.stepHistory.length - 2]
-    }?action=back`;
-  }
 
   if (formStep === "data-type") {
     // If current step is 'data-type', set the back link to start page ->

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -7,7 +7,7 @@ import {
   extractFormData,
   validateRequestBody,
 } from "../helperFunctions/helperFunctions";
-import { FormData, LegalGatewayStep, LegalPowerStep } from "../types/express";
+import { FormData, DataTypeStep, LegalGatewayStep, LegalPowerStep } from "../types/express";
 
 function parseJwt(token: string) {
   return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
@@ -53,8 +53,20 @@ const skipThisStep = (step: string, formdata: FormData) => {
       const legalGatewayStep = formdata.steps["legal-gateway"].value as LegalGatewayStep
       return legalGatewayStep.yes.checked || legalGatewayStep.other.checked
     }
+    case "lawful-basis-personal": {
+      // Skip lawful-basis-personal if answer to data-type was "special" or "none"
+      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
+      return DataTypeStep.special.checked || DataTypeStep.none.checked
+    }
+    case "lawful-basis-special": {
+      // Skip lawful-basis-special if answer to data-type was "personal" or "none"
+      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
+      return DataTypeStep.personal.checked || DataTypeStep.none.checked
+    }
     case "role": {
-      return formdata.steps["data-type"].value === "none" || formdata.steps["data-type"].value === "";
+      // Skip role if answer to data-type was "none" or "null"
+      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
+      return DataTypeStep.none.checked || formdata.steps["data-type"].value === "";
     }
     default: {
       return false;

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -37,7 +37,8 @@ const skipThisStep = (step: string, formdata: FormData) => {
   switch (step) {
     case "data-subjects": {
       // Skip data-subjects if the data-type is "none" i.e. anonymised
-      return formdata.steps["data-type"].value === "none";
+      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
+      return DataTypeStep.none.checked;
     }
     case "other-orgs": {
       // Skip other-orgs if the answer to data-access was "no"
@@ -169,7 +170,7 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   const formdata = req.session.acquirerForms[resourceID];
   const stepData = formdata.steps[formStep];
   const errorMessage = validateRequestBody(formStep, req.body);
-  
+
   if (!formdata || !formdata.steps[formStep]) {
     return res.status(400).send("Form data or step not found");
   }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -178,6 +178,8 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     backLink = `/acquirer/${resourceID}/${
       formdata.stepHistory[formdata.stepHistory.length - 1]
     }?action=back`;
+  } else {
+      backLink = `/acquirer/${resourceID}/start`;
   }
 
   res.render(`../views/acquirer/${formStep}.njk`, {

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -7,7 +7,13 @@ import {
   extractFormData,
   validateRequestBody,
 } from "../helperFunctions/helperFunctions";
-import { DataTypeStep, FormData, LawfulBasisSpecialStep, LegalGatewayStep, LegalPowerStep } from "../types/express";
+import {
+  DataTypeStep,
+  FormData,
+  LawfulBasisSpecialStep,
+  LegalGatewayStep,
+  LegalPowerStep,
+} from "../types/express";
 
 function parseJwt(token: string) {
   return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
@@ -37,7 +43,7 @@ const skipThisStep = (step: string, formdata: FormData) => {
   switch (step) {
     case "data-subjects": {
       // Skip data-subjects if the data-type is "none" i.e. anonymised
-      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep
+      const DataTypeStep = formdata.steps["data-type"].value as DataTypeStep;
       return DataTypeStep.none.checked;
     }
     case "other-orgs": {
@@ -46,32 +52,49 @@ const skipThisStep = (step: string, formdata: FormData) => {
     }
     case "legal-power-advice": {
       // Skip legal-power-advice if the answer to legal-power was "Yes"
-      const legalPowerStep = formdata.steps["legal-power"].value as LegalPowerStep
-      return legalPowerStep.yes.checked
+      const legalPowerStep = formdata.steps["legal-power"]
+        .value as LegalPowerStep;
+      return legalPowerStep.yes.checked;
     }
     case "legal-gateway-advice": {
       // Skip legal-gateway-advice if the answer to legal-gateway was "yes" or "other"
-      const legalGatewayStep = formdata.steps["legal-gateway"].value as LegalGatewayStep
-      return legalGatewayStep.yes.checked || legalGatewayStep.other.checked
+      const legalGatewayStep = formdata.steps["legal-gateway"]
+        .value as LegalGatewayStep;
+      return legalGatewayStep.yes.checked || legalGatewayStep.other.checked;
     }
     case "role": {
-      const data = formdata.steps["data-type"].value as DataTypeStep
-      return (data.none.checked || (data.personal.checked === undefined && data.special.checked === undefined))
+      const data = formdata.steps["data-type"].value as DataTypeStep;
+      return (
+        data.none.checked ||
+        (data.personal.checked === undefined &&
+          data.special.checked === undefined)
+      );
     }
     case "lawful-basis-personal": {
-      const data = formdata.steps["data-type"].value as DataTypeStep
-      return data.personal.checked === false || data.personal.checked === undefined
+      const data = formdata.steps["data-type"].value as DataTypeStep;
+      return (
+        data.personal.checked === false || data.personal.checked === undefined
+      );
     }
     case "lawful-basis-special": {
-      const data = formdata.steps["data-type"].value as DataTypeStep
-      return data.special.checked === false || data.special.checked === undefined
+      const data = formdata.steps["data-type"].value as DataTypeStep;
+      return (
+        data.special.checked === false || data.special.checked === undefined
+      );
     }
     case "lawful-basis-special-public-interest": {
-      const data = formdata.steps["lawful-basis-special"].value as LawfulBasisSpecialStep
-      return (data["reasons-of-public-interest"]?.checked === false || data["reasons-of-public-interest"]?.checked === undefined)
+      const data = formdata.steps["lawful-basis-special"]
+        .value as LawfulBasisSpecialStep;
+      return (
+        data["reasons-of-public-interest"]?.checked === false ||
+        data["reasons-of-public-interest"]?.checked === undefined
+      );
     }
     case "data-travel-location": {
-      return formdata.steps["data-travel"].value === "no" || formdata.steps["data-travel"].value === ""
+      return (
+        formdata.steps["data-travel"].value === "no" ||
+        formdata.steps["data-travel"].value === ""
+      );
     }
     default: {
       return false;
@@ -124,7 +147,7 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   const stepData = formdata.steps[formStep];
   const assetTitle = formdata.assetTitle;
 
-  if (req.query.action === 'back' && formdata.stepHistory) {
+  if (req.query.action === "back" && formdata.stepHistory) {
     formdata.stepHistory.pop();
   }
 
@@ -132,26 +155,30 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     stepData.skipped = true;
     return res.redirect(`/acquirer/${resourceID}/${stepData.nextStep}`);
   }
-  
-  let backLink = null; 
+
+  let backLink = null;
 
   if (!formdata.stepHistory) {
     formdata.stepHistory = [];
   }
-  
+
   // If we have history and are pressing back, we set the back link.
   if (formdata.stepHistory.length > 1) {
-    backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 2]}?action=back`;
- }
+    backLink = `/acquirer/${resourceID}/${
+      formdata.stepHistory[formdata.stepHistory.length - 2]
+    }?action=back`;
+  }
 
- if (formStep === 'data-type') {
-  // If current step is 'data-type', set the back link to start page -> 
-  // in preperation for Maddies current work before Annual leave data-type being the only page to start from
-  backLink = `/acquirer/${resourceID}/start`;
-} else if (formdata.stepHistory && formdata.stepHistory.length > 0) {
-  // Otherwise, set it to the previous step from stepHistory
-  backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 1]}?action=back`;
-}
+  if (formStep === "data-type") {
+    // If current step is 'data-type', set the back link to start page ->
+    // in preperation for Maddies current work before Annual leave data-type being the only page to start from
+    backLink = `/acquirer/${resourceID}/start`;
+  } else if (formdata.stepHistory && formdata.stepHistory.length > 0) {
+    // Otherwise, set it to the previous step from stepHistory
+    backLink = `/acquirer/${resourceID}/${
+      formdata.stepHistory[formdata.stepHistory.length - 1]
+    }?action=back`;
+  }
 
   res.render(`../views/acquirer/${formStep}.njk`, {
     requestId: formdata.requestId,
@@ -192,7 +219,7 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   if (!formdata.stepHistory) {
     formdata.stepHistory = [];
   }
-  
+
   // Check which button was clicked "Save and continue || Save and return"
   if (req.body.returnButton) {
     stepData.status = "IN PROGRESS";
@@ -207,7 +234,7 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   }
 
   stepData.status = "COMPLETED";
- 
+
   if (formdata.steps[formStep].nextStep) {
     return res.redirect(
       `/acquirer/${resourceID}/${formdata.steps[formStep].nextStep}`,

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -80,8 +80,8 @@ const skipThisStep = (step: string, formdata: FormData) => {
 };
 
 router.get("/:resourceID/start", async (req: Request, res: Response) => {
-  const backLink = req.headers.referer || "/";
   const resourceID = req.params.resourceID;
+  const backLink = req.headers.referer || `/share/${resourceID}/acquirer`;
 
   try {
     const resource = await fetchResourceById(resourceID);

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -109,6 +109,32 @@ type LawfulBasisSpecialStep = {
   "not-for-profit-bodies"?: LawfulBasis;
 };
 
+type LawfulSpecialPublicInterestStep = {
+  "statutory-government-purposes"?: LawfulBasis;
+  "administration-justice-parliamentary-purposes"?: LawfulBasis;
+  "equality-opportunity-or-treatment"?: LawfulBasis;
+  "preventing-or-detecting-unlawful-acts"?: LawfulBasis;
+  "protecting-the-public"?: LawfulBasis;
+  "racial-ethnic-diversity-senior-levels"?: LawfulBasis;
+  "regulatory-requirements"?: LawfulBasis;
+  "journalism-academia-art-literature"?: LawfulBasis;
+  "preventing-fraud"?: LawfulBasis;
+  "suspicion-terrorist-financing-or-money-laundering"?: LawfulBasis;
+  "support-particular-disability-or-mental-condition"?: LawfulBasis;
+  "counselling"?: LawfulBasis;
+  "safeguarding-children-individuals-risk"?: LawfulBasis;
+  "safeguarding-economic-well-being"?: LawfulBasis;
+  "insurance"?: LawfulBasis;
+  "occupational-pensions"?: LawfulBasis;
+  "political-parties"?: LawfulBasis;
+  "elected-representatives-responding-requests"?: LawfulBasis;
+  "disclosure-elected-representatives"?: LawfulBasis;
+  "informing-elected-representatives-about-prisoners"?: LawfulBasis;
+  "publication-legal-judgments"?: LawfulBasis;
+  "anti-doping-sport"?: LawfulBasis;
+  "standards-behaviour-sport"?: LawfulBasis;
+};
+
 export type StepValue =
   | string
   | DataTypeStep
@@ -119,6 +145,7 @@ export type StepValue =
   | DateStep
   | LawfulBasisPersonalStep
   | LawfulBasisSpecialStep
+  | LawfulSpecialPublicInterestStep
   | DeliveryStep
   | FormatStep;
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -15,6 +15,7 @@ interface FormData {
   status: string;
   sections: Record<string, Section>;
   steps: Record<string, Step>;
+  stepHistory?: string[];
 }
 
 export interface RequestBody {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -23,7 +23,11 @@ export interface RequestBody {
 }
 
 // Add id's here. Should only be able to handle single value
-type TextFieldStepID = "impact" | "data-subjects" | "data-required" | "disposal";
+type TextFieldStepID =
+  | "impact"
+  | "data-subjects"
+  | "data-required"
+  | "disposal";
 type RadioFieldStepID = "data-access" | "legal-review" | "role";
 
 interface Benefits {
@@ -47,7 +51,7 @@ type DataTypeStep = {
   personal: GenericDecisions;
   special: GenericDecisions;
   none: GenericDecisions;
-}
+};
 
 type ProjectAimStep = {
   aims: string;
@@ -62,8 +66,8 @@ type GenericDecisions = {
 type DeliveryStep = {
   "third-party": GenericDecisions;
   physical: GenericDecisions;
-  something: GenericDecisions
-}
+  something: GenericDecisions;
+};
 
 type FormatStep = {
   csv: GenericDecisions;

--- a/src/views/acquirer/lawful-basis-special-public-interest.njk
+++ b/src/views/acquirer/lawful-basis-special-public-interest.njk
@@ -1,0 +1,158 @@
+{% extends "page.njk" %}
+{%- from "govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" id="LawfulSpecialPublicInterestForm">
+      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+       {% set lawfulPublicInterestHTML %}
+          <p class="govuk-body">You may need help from a data protection specialist.</p>
+        {% endset %}
+      {{ govukCheckboxes({
+      name: "lawful-basis-special-public-interest",
+      fieldset: {
+          legend: {
+          text: "What is the substantial public interest for requesting special category data under UK GDPR?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l squish-hints"
+          }
+      },
+      hint: {
+          html: lawfulPublicInterestHTML
+      },
+      items: [
+          {
+          value: "statutory-government-purposes",
+          text: "Statutory and government purposes",
+          checked: savedValue["statutory-government-purposes"].checked
+          },
+           {
+          value: "administration-justice-parliamentary-purposes",
+          text: "Administration of justice and parliamentary purposes",
+          checked: savedValue["administration-justice-parliamentary-purposes"].checked
+          },
+          {
+          value: "equality-opportunity-or-treatment",
+          text: "Equality of opportunity or treatment",
+          checked: savedValue["equality-opportunity-or-treatment"].checked
+          },
+          {
+          value: "preventing-or-detecting-unlawful-acts",
+          text: "Preventing or detecting unlawful acts",
+          checked: savedValue["preventing-or-detecting-unlawful-acts"].checked
+          },
+             {
+          value: "protecting-the-public",
+          text: "Protecting the public",
+          checked: savedValue["protecting-the-public"].checked
+          },
+             {
+          value: "racial-ethnic-diversity-senior-levels",
+          text: "Racial and ethnic diversity at senior levels",
+          checked: savedValue["racial-ethnic-diversity-senior-levels"].checked
+          },
+             {
+          value: "regulatory-requirements",
+          text: "Regulatory requirements",
+          checked: savedValue["regulatory-requirements"].checked
+          },
+          {
+          value: "journalism-academia-art-literature",
+          text: "Journalism, academia, art and literature",
+          checked: savedValue["journalism-academia-art-literature"].checked
+          },
+          {
+          value: "preventing-fraud",
+          text: "Preventing fraud",
+          checked: savedValue["preventing-fraud"].checked
+          },
+             {
+          value: "suspicion-terrorist-financing-or-money-laundering",
+          text: "Suspicion of terrorist financing or money laundering",
+          checked: savedValue["suspicion-terrorist-financing-or-money-laundering"].checked
+          },
+             {
+          value: "support-particular-disability-or-mental-condition",
+          text: "Support for individuals with a particular disability or medical condition",
+          checked: savedValue["support-particular-disability-or-mental-condition"].checked
+          },
+             {
+          value: "counselling",
+          text: "Counselling",
+          checked: savedValue["counselling"].checked
+          },
+             {
+          value: "safeguarding-children-individuals-risk",
+          text: "Safeguarding of children and individuals at risk",
+          checked: savedValue["safeguarding-children-individuals-risk"].checked
+          },
+             {
+          value: "safeguarding-economic-well-being",
+          text: "Safeguarding of economic well-being of certain individuals",
+          checked: savedValue["safeguarding-economic-well-being"].checked
+          },
+             {
+          value: "insurance",
+          text: "Insurance",
+          checked: savedValue["insurance"].checked
+          },
+             {
+          value: "occupational-pensions",
+          text: "Occupational pensions",
+          checked: savedValue["occupational-pensions"].checked
+          },
+             {
+          value: "political-parties",
+          text: "Political parties",
+          checked: savedValue["political-parties"].checked
+          },
+             {
+          value: "elected-representatives-responding-requests",
+          text: "Elected representatives responding to requests",
+          checked: savedValue["elected-representatives-responding-requests"].checked
+          },
+             {
+          value: "disclosure-elected-representatives",
+          text: "Disclosure to elected representatives",
+          checked: savedValue["disclosure-elected-representatives"].checked
+          },
+             {
+          value: "informing-elected-representatives-about-prisoners",
+          text: "Informing elected representatives about prisoners",
+          checked: savedValue["informing-elected-representatives-about-prisoners"].checked
+          },
+             {
+          value: "publication-legal-judgments",
+          text: "Publication of legal judgments",
+          checked: savedValue["publication-legal-judgments"].checked
+          },
+             {
+          value: "anti-doping-sport",
+          text: "Anti-doping in sport",
+          checked: savedValue["anti-doping-sport"].checked
+          },
+             {
+          value: "standards-behaviour-sport",
+          text: "Standards of behaviour in sport",
+          checked: savedValue["standards-behaviour-sport"].checked
+        }       
+      ]
+      }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+          text: "Save and continue",
+          name: "continueButton",
+          value: "continue"
+      }) }}
+          {{ govukButton({
+          text: "Save and return",
+          classes: "govuk-button--secondary",
+          name: "returnButton",
+          value: "return"
+      }) }}
+    </div>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
In this PR, I've introduced the lawful-basis-special-public-interest page. To access this hidden page, users should select the "none" checkbox and navigate through the legal review page.

Furthermore, I've enriched the formData interface with a stepHistory feature. This ensures continuity in tracking page navigation within the session data.

Process Flow:

The journey starts at the data-type page.
Users progress through the flow based on prior selections.
Each navigational step gets logged into the stepHistory array.
The array accumulates steps until the user clicks on "Save and return".
Clicking "Save and return" clears the stepHistory array since it's no longer required once the user redirects to the overview page.