### PR TITLE
Implemented other-orgs page

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,7 +16,7 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
-  MoreOrganisation
+  MoreOrganisationStep
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -170,7 +170,7 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
         .filter(key => key.startsWith("org-name-"))
         .map(key => body[key]);
 
-    return orgValues as MoreOrganisation;
+    return orgValues as MoreOrganisationStep;
 }
   
   if (stepData.id === "data-type") {

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,6 +16,7 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
+  MoreOrganisation
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -162,6 +163,16 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
     return body[stepData.id] as StepValue;
   }
 
+  if (stepData.id === "other-orgs") {
+    console.log("IN THE EXTRACTFORMDATA FUNCTION", body, stepData)
+   
+    const orgValues = Object.keys(body)
+        .filter(key => key.startsWith("org-name-"))
+        .map(key => body[key]);
+
+    return orgValues as MoreOrganisation;
+}
+  
   if (stepData.id === "data-type") {
     return {
       personal: {

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -133,7 +133,7 @@ function isRadioField(id: string): id is RadioFieldStepID {
     "role",
     "data-travel",
     "protection-review",
-    "security-review"
+    "security-review",
   ].includes(id);
 }
 

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,7 +16,7 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
-  MoreOrganisationStep
+  MoreOrganisationStep,
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -164,15 +164,13 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
   }
 
   if (stepData.id === "other-orgs") {
-    console.log("IN THE EXTRACTFORMDATA FUNCTION", body, stepData)
-   
     const orgValues = Object.keys(body)
-        .filter(key => key.startsWith("org-name-"))
-        .map(key => body[key]);
+      .filter((key) => key.startsWith("org-name-"))
+      .map((key) => body[key]);
 
     return orgValues as MoreOrganisationStep;
-}
-  
+  }
+
   if (stepData.id === "data-type") {
     return {
       personal: {

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -92,7 +92,7 @@
       "id": "other-orgs",
       "name": "Other organisations",
       "status": "NOT STARTED",
-      "value": "",
+      "value": [""],
       "nextStep": "impact",
       "skipped": false
     },

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -173,7 +173,7 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
       formdata.stepHistory[formdata.stepHistory.length - 1]
     }?action=back`;
   } else {
-      backLink = `/acquirer/${resourceID}/start`;
+    backLink = `/acquirer/${resourceID}/start`;
   }
 
   res.render(`../views/acquirer/${formStep}.njk`, {
@@ -216,28 +216,38 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
-  if (req.body.addMoreOrgs) {  // If "Add another organisation" is clicked.
+  if (req.body.addMoreOrgs) {
+    // If "Add another organisation" is clicked.
     if (Array.isArray(formdata.steps["other-orgs"].value)) {
-        formdata.steps["other-orgs"].value.push('');  // Add a new empty string.
+      formdata.steps["other-orgs"].value.push(""); // Add a new empty string.
     } else {
-        // handle error or other logic if value isn't an array
-        console.error("Expected 'other-orgs' value to be an array but it wasn't.");
+      // handle error or other logic if value isn't an array
+      console.error(
+        "Expected 'other-orgs' value to be an array but it wasn't.",
+      );
     }
-    return res.redirect(`/acquirer/${resourceID}/other-orgs`);  // Refresh the current page.
+    return res.redirect(`/acquirer/${resourceID}/other-orgs`); // Refresh the current page.
   }
 
   if (req.body.removeOrg !== undefined) {
     const orgIndexToRemove = parseInt(req.body.removeOrg, 10) - 1;
-    if (formdata.steps["other-orgs"] && Array.isArray(formdata.steps["other-orgs"].value)) {
+    if (
+      formdata.steps["other-orgs"] &&
+      Array.isArray(formdata.steps["other-orgs"].value)
+    ) {
       const orgs = formdata.steps["other-orgs"].value as MoreOrganisationStep;
 
-      if (Number.isInteger(orgIndexToRemove) && orgIndexToRemove >= 0 && orgIndexToRemove < orgs.length) {
+      if (
+        Number.isInteger(orgIndexToRemove) &&
+        orgIndexToRemove >= 0 &&
+        orgIndexToRemove < orgs.length
+      ) {
         orgs.splice(orgIndexToRemove, 1);
       }
     }
     return res.redirect(`/acquirer/${resourceID}/other-orgs`);
   }
-  
+
   // Check which button was clicked "Save and continue || Save and return"
   if (req.body.returnButton) {
     stepData.status = "IN PROGRESS";

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -162,7 +162,6 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
-
   if (formStep === "data-type") {
     // If current step is 'data-type', set the back link to start page ->
     // in preperation for Maddies current work before Annual leave data-type being the only page to start from
@@ -216,6 +215,16 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
+  if (req.body.addMoreOrgs) {  // If "Add another organisation" is clicked.
+    if (Array.isArray(formdata.steps["other-orgs"].value)) {
+        formdata.steps["other-orgs"].value.push('');  // Add a new empty string.
+    } else {
+        // handle error or other logic if value isn't an array
+        console.error("Expected 'other-orgs' value to be an array but it wasn't.");
+    }
+    return res.redirect(`/acquirer/${resourceID}/other-orgs`);  // Refresh the current page.
+}
+  
   // Check which button was clicked "Save and continue || Save and return"
   if (req.body.returnButton) {
     stepData.status = "IN PROGRESS";

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -13,6 +13,7 @@ import {
   LawfulBasisSpecialStep,
   LegalGatewayStep,
   LegalPowerStep,
+  MoreOrganisationStep,
 } from "../types/express";
 
 function parseJwt(token: string) {
@@ -223,7 +224,19 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
         console.error("Expected 'other-orgs' value to be an array but it wasn't.");
     }
     return res.redirect(`/acquirer/${resourceID}/other-orgs`);  // Refresh the current page.
-}
+  }
+
+  if (req.body.removeOrg !== undefined) {
+    const orgIndexToRemove = parseInt(req.body.removeOrg, 10) - 1;
+    if (formdata.steps["other-orgs"] && Array.isArray(formdata.steps["other-orgs"].value)) {
+      const orgs = formdata.steps["other-orgs"].value as MoreOrganisationStep;
+
+      if (Number.isInteger(orgIndexToRemove) && orgIndexToRemove >= 0 && orgIndexToRemove < orgs.length) {
+        orgs.splice(orgIndexToRemove, 1);
+      }
+    }
+    return res.redirect(`/acquirer/${resourceID}/other-orgs`);
+  }
   
   // Check which button was clicked "Save and continue || Save and return"
   if (req.body.returnButton) {

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -25,3 +25,7 @@
     }
   }
 }
+
+.add-another__organisation:first-of-type {
+  margin-bottom:  govuk-spacing(5);
+}

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -27,5 +27,5 @@
 }
 
 .add-another__organisation:first-of-type {
-  margin-bottom:  govuk-spacing(5);
+  margin-bottom: govuk-spacing(5);
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -140,11 +140,11 @@ type LawfulBasisSpecialPublicInterestStep = {
   standards?: LawfulBasis;
 };
 
-type MoreOrganisation = string[];
+type MoreOrganisationStep = string[];
 
 export type StepValue =
-  | MoreOrganisation  
   | string
+  | MoreOrganisationStep  
   | DataTypeStep
   | ProjectAimStep
   | BenefitsStep

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -144,7 +144,7 @@ type MoreOrganisationStep = string[];
 
 export type StepValue =
   | string
-  | MoreOrganisationStep  
+  | MoreOrganisationStep
   | DataTypeStep
   | ProjectAimStep
   | BenefitsStep

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -140,7 +140,10 @@ type LawfulBasisSpecialPublicInterestStep = {
   standards?: LawfulBasis;
 };
 
+type MoreOrganisation = string[];
+
 export type StepValue =
+  | MoreOrganisation  
   | string
   | DataTypeStep
   | ProjectAimStep

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -28,8 +28,12 @@ type TextFieldStepID =
   | "data-subjects"
   | "data-required"
   | "disposal";
-  
-type RadioFieldStepID = "data-access" | "legal-review" | "role" | "security-review";
+
+type RadioFieldStepID =
+  | "data-access"
+  | "legal-review"
+  | "role"
+  | "security-review";
 
 interface Benefits {
   explanation?: string;

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -8,7 +8,8 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="otherOrgsForm">
-        <p class="govuk-body">What other organisations will access the data?</p> 
+        <h1 class="govuk-heading-l govuk-fieldset__legend govuk-fieldset__legend--l">What other organisations will access the data?</h1>
+        <div class="govuk-hint">List all the organisations you will be sharing the data with.</div>
 
         {% for org in savedValue %}
           <div class="govuk-grid-row">

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -8,18 +8,18 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="otherOrgsForm">
-        <div>
-          <p class="govuk-body">What other organisations will access the data?</p>
-        </div>
+          <p class="govuk-body">What other organisations will access the data?</p> 
 
-        {% for org in savedValue %}
-          {% call govukFieldset({
-            classes: "add-another__organisation" ,
-            legend: {
-              classes: 'govuk-fieldset__legend--m',
-              isPageHeading: false
-            }
-          }) %}
+          {% for org in savedValue %}
+            <div class="govuk-grid-column-two-thirds">
+              {% call govukFieldset({
+                classes: "add-another__organisation" ,
+                legend: {
+                  classes: 'govuk-fieldset__legend--m',
+                  isPageHeading: false
+                }
+              }) %}
+
             {{ govukInput({
               id: "org-name-" + loop.index,
               name: "org-name-" + loop.index,
@@ -30,7 +30,7 @@
                 'data-id': 'orgs[' + loop.index + ']'
               }
             }) }}
-
+            </div>
             {# Only show the remove button if it's not the first input #}
             {% if loop.index > 1 %}
               <p class="govuk-body">

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -14,7 +14,7 @@
 
         {% for org in savedValue %}
           {% call govukFieldset({
-            classes: "add-another__organisation",
+            classes: "add-another__organisation" ,
             legend: {
               classes: 'govuk-fieldset__legend--m',
               isPageHeading: false
@@ -30,8 +30,20 @@
                 'data-id': 'orgs[' + loop.index + ']'
               }
             }) }}
+
+            {# Only show the remove button if it's not the first input #}
+            {% if loop.index > 1 %}
+              <p class="govuk-body">
+                {{ govukButton({
+                  text: "Remove",
+                  name: "removeOrg",
+                  classes: "govuk-button govuk-button--secondary",
+                  value: loop.index
+                }) }}
+              </p>
+            {% endif %}
           {% endcall %}
-        {% endfor %}
+        {% endfor %}  
 
         <p class="govuk-body">
           {{ govukButton({

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -8,66 +8,72 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="otherOrgsForm">
-          <p class="govuk-body">What other organisations will access the data?</p> 
+        <p class="govuk-body">What other organisations will access the data?</p> 
 
-          {% for org in savedValue %}
+        {% for org in savedValue %}
+          <div class="govuk-grid-row">
+            
             <div class="govuk-grid-column-two-thirds">
               {% call govukFieldset({
-                classes: "add-another__organisation" ,
-                legend: {
-                  classes: 'govuk-fieldset__legend--m',
-                  isPageHeading: false
-                }
-              }) %}
-
-            {{ govukInput({
-              id: "org-name-" + loop.index,
-              name: "org-name-" + loop.index,
-              value: org,
-              classes: "govuk-input--width-20",
-              attributes: {
-                'data-name': 'orgs[' + loop.index + ']',
-                'data-id': 'orgs[' + loop.index + ']'
+              classes: "add-another__organisation" ,
+              legend: {
+                classes: 'govuk-fieldset__legend--m',
+                isPageHeading: false
               }
-            }) }}
+              }) %}
+                    {{ govukInput({
+                      id: "org-name-" + loop.index,
+                      name: "org-name-" + loop.index,
+                      value: org,
+                      classes: "govuk-input--width-20",
+                      attributes: {
+                        'data-name': 'orgs[' + loop.index + ']',
+                        'data-id': 'orgs[' + loop.index + ']'
+                      }
+                    }) }}
+                  {% endcall %}
+                </div>
+                
+                {# Only show the remove button if it's not the first input #}
+                {% if loop.index > 1 %}
+                  <div class="govuk-grid-column-one-third">
+                    <p class="govuk-body">
+                      {{ govukButton({
+                        text: "Remove",
+                        name: "removeOrg",
+                        classes: "govuk-button govuk-button--secondary",
+                        value: loop.index
+                      }) }}
+                    </p>
+                  </div>
+                {% endif %}
+                
+              </div>
+            {% endfor %}
+
+            <p class="govuk-body">
+              {{ govukButton({
+                text: "Add another organisation",
+                name: "addMoreOrgs",
+                classes: "govuk-button--secondary",
+                value: "true"
+              }) }}
+            </p>
+
+            <div class="govuk-button-group">
+              {{ govukButton({
+                text: "Save and continue",
+                name: "continueButton",
+                value: "continue"
+              }) }}
+              {{ govukButton({
+                text: "Save and return",
+                classes: "govuk-button--secondary",
+                name: "returnButton",
+                value: "return"
+              }) }}
             </div>
-            {# Only show the remove button if it's not the first input #}
-            {% if loop.index > 1 %}
-              <p class="govuk-body">
-                {{ govukButton({
-                  text: "Remove",
-                  name: "removeOrg",
-                  classes: "govuk-button govuk-button--secondary",
-                  value: loop.index
-                }) }}
-              </p>
-            {% endif %}
-          {% endcall %}
-        {% endfor %}  
-
-        <p class="govuk-body">
-          {{ govukButton({
-            text: "Add another organisation",
-            name: "addMoreOrgs",
-            classes: "govuk-button--secondary",
-            value: "true"
-          }) }}
-        </p>
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Save and continue",
-            name: "continueButton",
-            value: "continue"
-          }) }}
-          {{ govukButton({
-            text: "Save and return",
-            classes: "govuk-button--secondary",
-            name: "returnButton",
-            value: "return"
-          }) }}
-        </div>
-      </form>
+        </form>
     </div>
   </div>
 {% endblock %}

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -1,6 +1,7 @@
 {% extends "page.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -10,28 +11,49 @@
         <div>
           <p class="govuk-body">What other organisations will access the data?</p>
         </div>
-       {% for org in savedValue %}
-        {{ govukInput({
-            id: "org-name-" + loop.index,
-            name: "org-name-" + loop.index,
-            classes: "govuk-input--width-20",
-            value: org
-        }) }}
+
+        {% for org in savedValue %}
+          {% call govukFieldset({
+            classes: "add-another__organisation",
+            legend: {
+              classes: 'govuk-fieldset__legend--m',
+              isPageHeading: false
+            }
+          }) %}
+            {{ govukInput({
+              id: "org-name-" + loop.index,
+              name: "org-name-" + loop.index,
+              value: org,
+              classes: "govuk-input--width-20",
+              attributes: {
+                'data-name': 'orgs[' + loop.index + ']',
+                'data-id': 'orgs[' + loop.index + ']'
+              }
+            }) }}
+          {% endcall %}
         {% endfor %}
+
         <p class="govuk-body">
-          <button type="submit" name="addMoreOrgs" value="true" class="govuk-link">Add another organisation</button>
+          {{ govukButton({
+            text: "Add another organisation",
+            name: "addMoreOrgs",
+            classes: "govuk-button--secondary",
+            value: "true"
+          }) }}
         </p>
-        {{ govukButton({
-          text: "Save and continue",
-          name: "continueButton",
-          value: "continue"
-        }) }}
-        {{ govukButton({
-          text: "Save and return",
-          classes: "govuk-button--secondary",
-          name: "returnButton",
-          value: "return"
-        }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and continue",
+            name: "continueButton",
+            value: "continue"
+          }) }}
+          {{ govukButton({
+            text: "Save and return",
+            classes: "govuk-button--secondary",
+            name: "returnButton",
+            value: "return"
+          }) }}
         </div>
       </form>
     </div>

--- a/src/views/acquirer/other-orgs.njk
+++ b/src/views/acquirer/other-orgs.njk
@@ -1,0 +1,39 @@
+{% extends "page.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+      <form method="POST" id="otherOrgsForm">
+        <div>
+          <p class="govuk-body">What other organisations will access the data?</p>
+        </div>
+       {% for org in savedValue %}
+        {{ govukInput({
+            id: "org-name-" + loop.index,
+            name: "org-name-" + loop.index,
+            classes: "govuk-input--width-20",
+            value: org
+        }) }}
+        {% endfor %}
+        <p class="govuk-body">
+          <button type="submit" name="addMoreOrgs" value="true" class="govuk-link">Add another organisation</button>
+        </p>
+        {{ govukButton({
+          text: "Save and continue",
+          name: "continueButton",
+          value: "continue"
+        }) }}
+        {{ govukButton({
+          text: "Save and return",
+          classes: "govuk-button--secondary",
+          name: "returnButton",
+          value: "return"
+        }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Initially the prototype would show the "Add another organisation" as an anchor, having tried to implement this and realising if I where to create this as an anchor and set an action in the backend to addOrgs the task would grow much larger as we are customising an anchor instead of a form submit.
After the stand-up 25/08, we the devs settled with having the "Add another organisation" as a button as it would be easier for handling form actions

Backend Handling with addOrgs and removeOrgs

Renaming Type for Clarity: ```type MoreOrganisation = string[]; -> MoreOrganisationStep ``` 

Accessibility Improvements: [design-patterns.service.justice.gov.uk](https://design-patterns.service.justice.gov.uk/components/add-another/) docs, under accessibility it states:

![image](https://github.com/co-cddo/data-marketplace/assets/71328022/87c165e2-0b26-447c-b5a2-e00ccabb228c)

"People with low vision have also reported difficulty interacting with the remove button. This is because by default it is aligned to the right of the page away from their main focus."

So I have gone ahead with sticking the remove button beside all inputs except the initial index of 0 input.

