### PR TITLE
Dmbm 731/manage shares page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import cookieRoutes from "./routes/cookieRoutes";
 import loginRoutes from "./routes/loginRoutes";
 import authRoutes from "./routes/authRoutes";
 import profileRoutes from "./routes/profileRoutes";
+import manageRoutes from "./routes/supplierRoutes";
 import path from "path";
 import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
@@ -122,6 +123,7 @@ app.use("/profile", profileRoutes);
 app.use("/find", findRoutes);
 app.use("/share", shareRoutes);
 app.use("/acquirer", acquirerRoutes);
+app.use("/manage-shares", manageRoutes);
 app.use("/cookie-settings", cookieRoutes);
 
 // Error handling

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -1,0 +1,8 @@
+import express, { Request, Response } from "express";
+const router = express.Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  res.render("../views/supplier/manage-shares.njk");
+});
+
+export default router;

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -2,7 +2,10 @@ import express, { Request, Response } from "express";
 const router = express.Router();
 
 router.get("/", async (req: Request, res: Response) => {
-  res.render("../views/supplier/manage-shares.njk");
+  const backLink = req.headers.referer || "/";
+  res.render("../views/supplier/manage-shares.njk",{
+    backLink
+  });
 });
 
 export default router;

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -3,8 +3,8 @@ const router = express.Router();
 
 router.get("/", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
-  res.render("../views/supplier/manage-shares.njk",{
-    backLink
+  res.render("../views/supplier/manage-shares.njk", {
+    backLink,
   });
 });
 

--- a/src/stylesheets/_masthead.scss
+++ b/src/stylesheets/_masthead.scss
@@ -7,7 +7,6 @@ $osx-font-smoothing: grayscale;
   padding-top: 0;
   color: #ffffff;
   background-color: govuk-colour("blue");
-  margin-top: -10px;
 
   &__title {
     font-family: $font-family;

--- a/src/stylesheets/_navigation.scss
+++ b/src/stylesheets/_navigation.scss
@@ -4,17 +4,20 @@ $navigation-height: 50px;
   border-bottom: 1px solid $govuk-border-colour;
   background-color: govuk-colour("white");
 }
-a, .govuk-link, .app-task-list__task-name > a {
+a,
+.govuk-link,
+.app-task-list__task-name > a {
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-decoration: underline;
-  text-decoration-thickness: max(1px, .0625rem);
+  text-decoration-thickness: max(1px, 0.0625rem);
   text-underline-offset: 0.1em;
 }
 
-a:hover, .govuk-link:hover {
-  text-decoration-thickness: max(3px, .1875rem, .12em);
+a:hover,
+.govuk-link:hover {
+  text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
   -webkit-text-decoration-skip-ink: none;
   text-decoration-skip-ink: none;
   -webkit-text-decoration-skip: none;

--- a/src/stylesheets/_navigation.scss
+++ b/src/stylesheets/_navigation.scss
@@ -3,7 +3,6 @@ $navigation-height: 50px;
 .app-navigation {
   border-bottom: 1px solid $govuk-border-colour;
   background-color: govuk-colour("white");
-  margin-top: 10px;
 }
 a, .govuk-link, .app-task-list__task-name > a {
   font-family: "GDS Transport", arial, sans-serif;

--- a/src/stylesheets/_navigation.scss
+++ b/src/stylesheets/_navigation.scss
@@ -5,9 +5,21 @@ $navigation-height: 50px;
   background-color: govuk-colour("white");
   margin-top: 10px;
 }
-a.govuk-link {
+a, .govuk-link, .app-task-list__task-name > a {
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   text-decoration: underline;
-  text-underline-offset: 2px; /* adjust distance as required */
+  text-decoration-thickness: max(1px, .0625rem);
+  text-underline-offset: 0.1em;
+}
+
+a:hover, .govuk-link:hover {
+  text-decoration-thickness: max(3px, .1875rem, .12em);
+  -webkit-text-decoration-skip-ink: none;
+  text-decoration-skip-ink: none;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip: none;
 }
 .app-navigation__list {
   margin: 0;

--- a/src/views/home.njk
+++ b/src/views/home.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l">Manage data shares</h2>
     <p class="govuk-body">Set up and manage your data shares so you can share your data assets with other government organisations.</p>
-    <a href="#" class="govuk-button" data-module="govuk-button">
+    <a href="{{assetpath}}/manage-shares" class="govuk-button" data-module="govuk-button">
       Manage data shares
     </a>
   </div>

--- a/src/views/supplier/manage-shares.njk
+++ b/src/views/supplier/manage-shares.njk
@@ -1,6 +1,4 @@
 {% extends "page.njk" %}
-{%- from "govuk/components/radios/macro.njk" import govukRadios -%}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/src/views/supplier/manage-shares.njk
+++ b/src/views/supplier/manage-shares.njk
@@ -1,0 +1,23 @@
+{% extends "page.njk" %}
+{%- from "govuk/components/radios/macro.njk" import govukRadios -%}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Manage data share requests</h1>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-l">Received requests</h2>
+    <p class="govuk-body">View current and completed requests which are managed by your department.</p>
+    <p class="govuk-body"><a href="received-requests" class="govuk-link">View received requests</a></p>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-l">Created requests</h2>
+    <p class="govuk-body">View pending, submitted and completed requests to access data owned by others.</p>
+    <p class="govuk-body"><a href="created-requests" class="govuk-link">View created requests</a></p>
+  </div>
+</div>
+{% endblock %} 


### PR DESCRIPTION
Implemented the manage share page

I've noticed that amongst most pages, including the manage-share page all the govuk-links when hovering over would not show the underline. I have implemented the SCSS for this to match the prototype.
[link to styling demo](https://gyazo.com/b0962450e4c359728667abc239dd322c)

Added the backLink for this page, takes the user to '/' home

The navigation bar had a margin-top, removed this to match prototype.
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/553a3800-e6a8-4283-aee9-34ac32bcfd92)

