### PR TITLE
DMBM-763: Logic for acquirer overview page

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -132,7 +132,7 @@ function isRadioField(id: string): id is RadioFieldStepID {
     "role",
     "data-travel",
     "protection-review",
-    "security-review"
+    "security-review",
   ].includes(id);
 }
 

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -52,7 +52,7 @@
     "data-subjects": {
       "id": "data-subjects",
       "name": "Data subjects",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "project-aims",
       "skipped": false
@@ -60,7 +60,7 @@
     "project-aims": {
       "id": "project-aims",
       "name": "Project aims",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": {
         "aims": "",
         "explanation": ""
@@ -70,28 +70,28 @@
     "data-required": {
       "id": "data-required",
       "name": "Data required",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "benefits"
     },
     "benefits": {
       "id": "benefits",
       "name": "Benefits",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": [],
       "nextStep": "data-access"
     },
     "data-access": {
       "id": "data-access",
       "name": "Data access",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "other-orgs"
     },
     "other-orgs": {
       "id": "other-orgs",
       "name": "Other organisations",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "impact",
       "skipped": false
@@ -99,14 +99,14 @@
     "impact": {
       "id": "impact",
       "name": "Impact if data not given",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "date"
     },
     "date": {
       "id": "date",
       "name": "Date required",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": {
         "day": null,
         "month": null,
@@ -117,14 +117,14 @@
     "legal-power": {
       "id": "legal-power",
       "name": "Legal power",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "legal-power-advice"
     },
     "legal-power-advice": {
       "id": "legal-power-advice",
       "name": "Legal power advice",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "legal-gateway",
       "skipped": false
@@ -132,14 +132,14 @@
     "legal-gateway": {
       "id": "legal-gateway",
       "name": "Legal gateway",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "legal-gateway-advice"
     },
     "legal-gateway-advice": {
       "id": "legal-gateway-advice",
       "name": "Legal gateway advice",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "legal-review",
       "skipped": false
@@ -155,7 +155,7 @@
     "lawful-basis-personal": {
       "id": "lawful-basis-personal",
       "name": "Lawful basis for personal data",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": [],
       "nextStep": "lawful-basis-special",
       "skipped": false
@@ -163,7 +163,7 @@
     "lawful-basis-special": {
       "id": "lawful-basis-special",
       "name": "Lawful basis for special category data",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": [],
       "nextStep": "lawful-basis-special-public-interest",
       "skipped": false
@@ -171,7 +171,7 @@
     "lawful-basis-special-public-interest": {
       "id": "lawful-basis-special-public-interest",
       "name": "Lawful basis",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": [],
       "nextStep": "data-travel",
       "skipped": false
@@ -179,14 +179,14 @@
     "data-travel": {
       "id": "data-travel",
       "name": "Data travel outside UK",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "data-travel-location"
     },
     "data-travel-location": {
       "id": "data-travel-location",
       "name": "Data travel outside UK",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "role",
       "skipped": false
@@ -194,7 +194,7 @@
     "role": {
       "id": "role",
       "name": "Role of organisation",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "protection-review",
       "skipped": false
@@ -215,20 +215,20 @@
     "delivery": {
       "id": "delivery",
       "name": "Data delivery",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "nextStep": "format"
     },
     "format": {
       "id": "format",
       "name": "Data format",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "disposal"
     },
     "disposal": {
       "id": "disposal",
       "name": "Disposal of data",
-      "status": "NOT STARTED",
+      "status": "CANNOT START YET",
       "value": "",
       "nextStep": "security-review"
     },

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -54,8 +54,7 @@
       "name": "Data subjects",
       "status": "CANNOT START YET",
       "value": "",
-      "nextStep": "project-aims",
-      "skipped": false
+      "nextStep": "project-aims"
     },
     "project-aims": {
       "id": "project-aims",
@@ -126,8 +125,7 @@
       "name": "Legal power advice",
       "status": "CANNOT START YET",
       "value": "",
-      "nextStep": "legal-gateway",
-      "skipped": false
+      "nextStep": "legal-gateway"
     },
     "legal-gateway": {
       "id": "legal-gateway",
@@ -141,8 +139,7 @@
       "name": "Legal gateway advice",
       "status": "CANNOT START YET",
       "value": "",
-      "nextStep": "legal-review",
-      "skipped": false
+      "nextStep": "legal-review"
     },
     "legal-review": {
       "id": "legal-review",
@@ -157,24 +154,21 @@
       "name": "Lawful basis for personal data",
       "status": "CANNOT START YET",
       "value": [],
-      "nextStep": "lawful-basis-special",
-      "skipped": false
+      "nextStep": "lawful-basis-special"
     },
     "lawful-basis-special": {
       "id": "lawful-basis-special",
       "name": "Lawful basis for special category data",
       "status": "CANNOT START YET",
       "value": [],
-      "nextStep": "lawful-basis-special-public-interest",
-      "skipped": false
+      "nextStep": "lawful-basis-special-public-interest"
     },
     "lawful-basis-special-public-interest": {
       "id": "lawful-basis-special-public-interest",
       "name": "Lawful basis",
-      "status": "CANNOT START YET",
+      "status": "NOT REQUIRED",
       "value": [],
-      "nextStep": "data-travel",
-      "skipped": false
+      "nextStep": "data-travel"
     },
     "data-travel": {
       "id": "data-travel",
@@ -188,16 +182,14 @@
       "name": "Data travel outside UK",
       "status": "CANNOT START YET",
       "value": "",
-      "nextStep": "role",
-      "skipped": false
+      "nextStep": "role"
     },
     "role": {
       "id": "role",
       "name": "Role of organisation",
       "status": "CANNOT START YET",
       "value": "",
-      "nextStep": "protection-review",
-      "skipped": false
+      "nextStep": "protection-review"
     },
     "protection-review": {
       "id": "protection-review",
@@ -244,7 +236,8 @@
       "id": "check",
       "name": "Check answers",
       "status": "CANNOT START YET",
-      "blockedBy": ["legal-review", "protection-review", "security-review"]
+      "blockedBy": ["legal-review", "protection-review", "security-review"],
+      "nextStep": "start"
     }
   }
 }

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -238,7 +238,7 @@
       "name": "Check answers",
       "status": "CANNOT START YET",
       "blockedBy": ["legal-review", "protection-review", "security-review"],
-      "nextStep": "start"
+      "nextStep": "declaration"
     }
   }
 }

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -4,6 +4,7 @@
   "assetTitle": "",
   "ownedBy": "",
   "status": "Request incomplete",
+  "completedSections": 0,
   "overviewSections": {
     "purpose": {
       "name": "Purpose of the data share section",
@@ -59,7 +60,7 @@
     "project-aims": {
       "id": "project-aims",
       "name": "Project aims",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": {
         "aims": "",
         "explanation": ""
@@ -69,28 +70,28 @@
     "data-required": {
       "id": "data-required",
       "name": "Data required",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "benefits"
     },
     "benefits": {
       "id": "benefits",
       "name": "Benefits",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": [],
       "nextStep": "data-access"
     },
     "data-access": {
       "id": "data-access",
       "name": "Data access",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "other-orgs"
     },
     "other-orgs": {
       "id": "other-orgs",
       "name": "Other organisations",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "impact",
       "skipped": false
@@ -98,14 +99,14 @@
     "impact": {
       "id": "impact",
       "name": "Impact if data not given",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "date"
     },
     "date": {
       "id": "date",
       "name": "Date required",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": {
         "day": null,
         "month": null,
@@ -116,7 +117,7 @@
     "legal-power": {
       "id": "legal-power",
       "name": "Legal power",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "legal-power-advice"
     },
@@ -130,7 +131,7 @@
     "legal-gateway": {
       "id": "legal-gateway",
       "name": "Legal gateway",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "legal-gateway-advice"
     },
@@ -173,14 +174,14 @@
     "data-travel": {
       "id": "data-travel",
       "name": "Data travel outside UK",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "data-travel-location"
     },
     "data-travel-location": {
       "id": "data-travel-location",
       "name": "Data travel outside UK",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "role"
     },
@@ -207,20 +208,20 @@
     "delivery": {
       "id": "delivery",
       "name": "Data delivery",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "nextStep": "format"
     },
     "format": {
       "id": "format",
       "name": "Data format",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "disposal"
     },
     "disposal": {
       "id": "disposal",
       "name": "Disposal of data",
-      "status": "CANNOT START YET",
+      "status": "NOT STARTED",
       "value": "",
       "nextStep": "security-review"
     },

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -138,7 +138,6 @@ const updateStepsStatus = (
     }
   }
 
-  // Check some of 
   if (currentStep === "data-access") {
     if (stepValue === "no") {
       formdata.steps["other-orgs"].status = "NOT REQUIRED";
@@ -314,8 +313,9 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
 
   if (formdata.stepHistory && formdata.stepHistory.length > 0) {
     // Otherwise, set it to the previous step from stepHistory
-    backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 1]
-      }?action=back`;
+    backLink = `/acquirer/${resourceID}/${
+      formdata.stepHistory[formdata.stepHistory.length - 1]
+    }?action=back`;
   } else {
     backLink = `/acquirer/${resourceID}/start`;
   }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -124,10 +124,12 @@ const updateStepsStatus = (
       ].forEach((s) => notRequiredSteps.add(s));
     }
 
+    // Set everything that's not required to NOT REQUIRED
     for (const s of notRequiredSteps) {
       formdata.steps[s].status = "NOT REQUIRED";
     }
 
+    // Set everything that needs to be completed to NOT STARTED
     for (const s of notStartedSteps) {
       const stepStatus = formdata.steps[s].status;
       if (!["COMPLETED", "IN PROGRESS"].includes(stepStatus)) {
@@ -136,6 +138,7 @@ const updateStepsStatus = (
     }
   }
 
+  // Check some of 
   if (currentStep === "data-access") {
     if (stepValue === "no") {
       formdata.steps["other-orgs"].status = "NOT REQUIRED";
@@ -190,7 +193,7 @@ const updateStepsStatus = (
   }
 
   // Loop over all the steps in each section to check whether the
-  //  section is complete and/or the 'review' step can be enabled
+  //  section is complete and/or the 'check' step can be enabled
 
   if (everyStepCompleted(purposeSteps, formdata)) {
     completedSections.add("purpose");
@@ -199,12 +202,14 @@ const updateStepsStatus = (
   }
 
   if (everyStepCompleted(legalSteps, formdata)) {
+    // If all the legal steps AND the legal review is completed, legal is done.
     if (formdata.steps["legal-review"].status === "COMPLETED") {
       completedSections.add("legal");
     } else {
       formdata.steps["legal-review"].status = "NOT STARTED";
     }
   } else {
+    // If not all of the legal steps are Completed, legal review cannot be started
     formdata.steps["legal-review"].status = "CANNOT START YET";
     completedSections.delete("legal");
   }
@@ -241,6 +246,7 @@ const updateStepsStatus = (
     formdata.steps["check"].status = "CANNOT START YET";
   }
 
+  // Update the number of completed sections
   formdata.completedSections = completedSections.size;
 };
 
@@ -389,9 +395,10 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   // Check which button was clicked "Save and continue || Save and return"
   let redirectURL = `/acquirer/${resourceID}/start`;
   if (req.body.returnButton) {
+    // If save and return was clicked, clear the step history
     formdata.stepHistory = [];
   } else {
-    // Add the current step to the history if it's not already there
+    // Otherwise add the current step to the history if it's not already there
     if (formdata.stepHistory.indexOf(formStep) === -1) {
       formdata.stepHistory.push(formStep);
     }

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -156,10 +156,14 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
 
   stepData.status = "COMPLETED";
 
-  if (formdata.steps[formStep].nextStep) {
-    return res.redirect(
-      `/acquirer/${resourceID}/${formdata.steps[formStep].nextStep}`,
-    );
+  // Set the status of the next step to "NOT STARTED"
+  const nextStep = formdata.steps[formStep].nextStep;
+  if (nextStep && formdata.steps[nextStep]) {
+    formdata.steps[nextStep].status = "NOT STARTED";
+  }
+
+  if (nextStep) {
+    return res.redirect(`/acquirer/${resourceID}/${nextStep}`);
   } else {
     // Handle case when nextStep is not defined
     return res.redirect(`/acquirer/${resourceID}/start`);

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -159,7 +159,7 @@ interface Step {
   name: string;
   status: string;
   value: StepValue;
-  nextStep?: string;
+  nextStep: string;
   blockedBy?: string[];
   errorMessage?: string;
   skipped?: boolean;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -12,6 +12,7 @@ interface FormData {
   assetTitle: string;
   dataAsset: string;
   ownedBy: string;
+  completedSections: number;
   status: string;
   sections: Record<string, Section>;
   steps: Record<string, Step>;
@@ -28,8 +29,12 @@ type TextFieldStepID =
   | "data-subjects"
   | "data-required"
   | "disposal";
-  
-type RadioFieldStepID = "data-access" | "legal-review" | "role" | "security-review";
+
+type RadioFieldStepID =
+  | "data-access"
+  | "legal-review"
+  | "role"
+  | "security-review";
 
 interface Benefits {
   explanation?: string;

--- a/src/views/acquirer/data-required.njk
+++ b/src/views/acquirer/data-required.njk
@@ -5,13 +5,15 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: {{requestId}}</span>
     <form method="post">
       {{ govukTextarea({
             id: "data-required",
             name: "data-required",
             label: {
                 text: "What data from " + assetTitle + " do you need?",
-                classes: "govuk-label--m"
+                isPageHeading: true,
+                classes: "govuk-label--l"
             },
             rows: 5,
             value: savedValue

--- a/src/views/acquirer/project-aims.njk
+++ b/src/views/acquirer/project-aims.njk
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: {{requestId}}</span>
     <form method="post">
       {{ govukTextarea({
         name: "aims",
@@ -13,9 +14,6 @@
           text: "What are the aims of your project?",
           classes: "govuk-label--l",
           isPageHeading: true
-        },
-        hint: {
-          text: "Request ID: " + requestId
         },
         rows: 5,
         value: savedValue.aims

--- a/src/views/acquirer/start.njk
+++ b/src/views/acquirer/start.njk
@@ -9,7 +9,7 @@
         {{resource.title}}
       </h1>
       <h2 class="app-task-list__section">{{formdata.status}}</h2>
-      <p class="govuk-body govuk-!-margin-bottom-2">You have completed 0 of 5 sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-2">You have completed {{formdata.completedSections}} of 5 sections.</p>
       <p class="govuk-body govuk-!-margin-bottom-7">More sections may be added depending on your answers.</p>
       <ol class="app-task-list">
         {% for key, section in formdata.overviewSections %}

--- a/src/views/acquirer/start.njk
+++ b/src/views/acquirer/start.njk
@@ -23,7 +23,7 @@
                 {% set s = formdata.steps[step] %}
                 <li class="app-task-list__item">
                   <span class="app-task-list__task-name">
-                    {% if s.status != "CANNOT START YET" %}
+                    {% if s.status not in["CANNOT START YET", "NOT REQUIRED"] %}
                       <a href="{{ s.id }}" class="govuk-link">
                         {{ s.name }}
                       </a>
@@ -31,7 +31,7 @@
                       {{ s.name }}
                     {% endif %}
                   </span>
-                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag">{{ s.status }}</strong>
+                  <strong class="govuk-tag {{'govuk-tag--grey' if s.status in ['CANNOT START YET', 'NOT STARTED', 'IN PROGRESS']}} {{'govuk-tag--blue' if s.status in ['NOT REQUIRED']}} app-task-list__tag">{{ s.status }}</strong>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
# Logic for Overview page

The main change is that I've removed the `skipThisStep` function and replaced it with an `updateStepsStatus` function. `updateStepsStatus` gets called in the `POST` route every time a form page is submitted, and updates the status of the all other steps in the form depending on the current answer.

The `GET` route now just checks the status of the current step to decide whether to skip it. If a step is `NOT REQUIRED` or `CANNOT START YET` then the step is skipped and we redirect to the `nextStep`.

I've un-done Maddie's previous change and set the initial status of all of the steps to match [the prototype](https://miro.com/app/board/uXjVM6uSazQ=/?moveToWidget=3458764561693854106&cot=14). There are quite a few places where there are differences between the prototype and the [process map](https://miro.com/app/board/uXjVM5RD4Go=/), so I've decided to follow the prototype where there are any conflicts.
(Once the `data-type` question has been answered all of the statuses get updated anyway)

`updateStepsStatus` mainly contains loads of `if/else` statements to check the status of the current step and update the status of any other steps that depend on it.
In `updateStepsStatus` I've also included a check for whether the `Save and Return` button was pressed, so that this function is now the only place where the status of a step gets updated.
`updateStepsStatus` also contains some loops that check the status of all of the steps in a particular category, so that the `-review` and `check` pages can be enabled, and the `You have completed X of 5 sections` bit on the overview page can be updated.

(I'd recommend starting by just clicking through the UI a bit to see if this works as expected, rather than reading though all the `if/else`s in detail!)