### PR TITLE
Acquirer missing UI refactor

### DIFF
--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,7 +16,7 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
-  MoreOrganisationStep,
+  GenericStringArray
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -142,8 +142,7 @@ function isTextField(id: string): id is TextFieldStepID {
     "impact",
     "data-subjects",
     "data-required",
-    "disposal",
-    "data-travel-location",
+    "disposal"
   ].includes(id);
 }
 
@@ -169,7 +168,15 @@ const extractFormData = (stepData: Step, body: RequestBody): StepValue => {
       .filter((key) => key.startsWith("org-name-"))
       .map((key) => body[key]);
 
-    return orgValues as MoreOrganisationStep;
+    return orgValues as GenericStringArray;
+  }
+
+  if (stepData.id === "data-travel-location") {
+    const countryValues = Object.keys(body)
+      .filter((key) => key.startsWith("country-name-"))
+      .map((key) => body[key]);
+
+    return countryValues as GenericStringArray;
   }
 
   if (stepData.id === "data-type") {

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -16,7 +16,7 @@ import {
   RadioFieldStepID,
   TextFieldStepID,
   DeliveryStep,
-  GenericStringArray
+  GenericStringArray,
 } from "../types/express";
 
 function validateDate(day: number, month: number, year: number): string {
@@ -138,12 +138,7 @@ function isRadioField(id: string): id is RadioFieldStepID {
 }
 
 function isTextField(id: string): id is TextFieldStepID {
-  return [
-    "impact",
-    "data-subjects",
-    "data-required",
-    "disposal"
-  ].includes(id);
+  return ["impact", "data-subjects", "data-required", "disposal"].includes(id);
 }
 
 const extractFormData = (stepData: Step, body: RequestBody): StepValue => {

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -182,7 +182,7 @@
       "id": "data-travel-location",
       "name": "Data travel outside UK",
       "status": "NOT STARTED",
-      "value": "",
+      "value": [""],
       "nextStep": "role"
     },
     "role": {

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -384,9 +384,7 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   }
 
   if (req.body.addCountry) {
-    console.log("stepData", stepData);
     if (Array.isArray(formdata.steps["data-travel-location"].value)) {
-      console.log("stepDatassss", stepData);
       formdata.steps["data-travel-location"].value.push(""); // Add a new empty string.
     } else {
       // handle error or other logic if value isn't an array

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -14,7 +14,7 @@ import {
   LegalGatewayStep,
   LegalPowerStep,
   StepValue,
-  MoreOrganisationStep,
+  GenericStringArray
 } from "../types/express";
 
 function parseJwt(token: string) {
@@ -342,7 +342,6 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   } else {
     backLink = `/acquirer/${resourceID}/start`;
   }
-
   res.render(`../views/acquirer/${formStep}.njk`, {
     requestId: formdata.requestId,
     assetId: formdata.dataAsset,
@@ -384,6 +383,40 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
+
+  if (req.body.addCountry) {
+    console.log("stepData", stepData)
+    if (Array.isArray(formdata.steps["data-travel-location"].value)) {
+       console.log("stepDatassss", stepData)
+      formdata.steps["data-travel-location"].value.push(""); // Add a new empty string.
+    } else {
+      // handle error or other logic if value isn't an array
+      console.error(
+        "Expected 'data-travel-location' value to be an array but it wasn't.",
+      );
+    }
+    return res.redirect(`/acquirer/${resourceID}/data-travel-location`);
+  }
+
+  if (req.body.removeCountry !== undefined) {
+    const countryIndexToRemove = parseInt(req.body.removeCountry, 10) - 1;
+    if (
+      formdata.steps["data-travel-location"] &&
+      Array.isArray(formdata.steps["data-travel-location"].value)
+    ) {
+      const country = formdata.steps["data-travel-location"].value as GenericStringArray;
+
+      if (
+        Number.isInteger(countryIndexToRemove) &&
+        countryIndexToRemove >= 0 &&
+        countryIndexToRemove < country.length
+      ) {
+        country.splice(countryIndexToRemove, 1);
+      }
+    }
+    return res.redirect(`/acquirer/${resourceID}/data-travel-location`);
+  }
+
   if (req.body.addMoreOrgs) {
     // If "Add another organisation" is clicked.
     if (Array.isArray(formdata.steps["other-orgs"].value)) {
@@ -396,13 +429,14 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     }
     return res.redirect(`/acquirer/${resourceID}/other-orgs`); // Refresh the current page.
   }
+
   if (req.body.removeOrg !== undefined) {
     const orgIndexToRemove = parseInt(req.body.removeOrg, 10) - 1;
     if (
       formdata.steps["other-orgs"] &&
       Array.isArray(formdata.steps["other-orgs"].value)
     ) {
-      const orgs = formdata.steps["other-orgs"].value as MoreOrganisationStep;
+      const orgs = formdata.steps["other-orgs"].value as GenericStringArray;
 
       if (
         Number.isInteger(orgIndexToRemove) &&

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -14,7 +14,7 @@ import {
   LegalGatewayStep,
   LegalPowerStep,
   StepValue,
-  GenericStringArray
+  GenericStringArray,
 } from "../types/express";
 
 function parseJwt(token: string) {
@@ -277,7 +277,7 @@ router.get("/:resourceID/start", async (req: Request, res: Response) => {
     }
     const assetTitle = resource.title;
     const contactPoint = resource.contactPoint;
-  
+
     if (!contactPoint) {
       res.status(404).send("Contact point not found");
       return;
@@ -307,7 +307,7 @@ router.get("/:resourceID/start", async (req: Request, res: Response) => {
 router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   const resourceID = req.params.resourceID;
   const formStep = req.params.step;
-  
+
   if (!req.session.acquirerForms?.[resourceID]) {
     return res.redirect(`/share/${resourceID}/acquirer`);
   }
@@ -383,11 +383,10 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
-
   if (req.body.addCountry) {
-    console.log("stepData", stepData)
+    console.log("stepData", stepData);
     if (Array.isArray(formdata.steps["data-travel-location"].value)) {
-       console.log("stepDatassss", stepData)
+      console.log("stepDatassss", stepData);
       formdata.steps["data-travel-location"].value.push(""); // Add a new empty string.
     } else {
       // handle error or other logic if value isn't an array
@@ -404,7 +403,8 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
       formdata.steps["data-travel-location"] &&
       Array.isArray(formdata.steps["data-travel-location"].value)
     ) {
-      const country = formdata.steps["data-travel-location"].value as GenericStringArray;
+      const country = formdata.steps["data-travel-location"]
+        .value as GenericStringArray;
 
       if (
         Number.isInteger(countryIndexToRemove) &&

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -2,7 +2,6 @@ import express, { Request, Response } from "express";
 import { DateStep } from "../types/express";
 const router = express.Router();
 
-
 // Function to get the tag class based on the status value
 function getStatusClass(status: string): string {
   switch (status) {
@@ -28,7 +27,20 @@ router.get("/created-requests", async (req: Request, res: Response) => {
   const acquirerForms = req.session.acquirerForms || {};
   const backLink = req.headers.referer || "/";
 
-  const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
   const tableRows = [];
 
   for (const [key, formData] of Object.entries(acquirerForms)) {
@@ -42,11 +54,17 @@ router.get("/created-requests", async (req: Request, res: Response) => {
       formattedDate = `${dateValue.day} ${monthName} ${dateValue.year}`;
     }
     const row = [
-      { html: `<a href="/acquirer/${formData.dataAsset}/start">${formData.requestId}</a>` },
+      {
+        html: `<a href="/acquirer/${formData.dataAsset}/start">${formData.requestId}</a>`,
+      },
       { text: formData.assetTitle },
       { text: formData.ownedBy },
       { text: formattedDate },
-      { html: `<span class="govuk-tag ${getStatusClass(formData.status)}">${formData.status}</span>` }
+      {
+        html: `<span class="govuk-tag ${getStatusClass(formData.status)}">${
+          formData.status
+        }</span>`,
+      },
     ];
     tableRows.push(row);
   }
@@ -55,9 +73,8 @@ router.get("/created-requests", async (req: Request, res: Response) => {
     backLink,
     acquirerForms,
     getStatusClass,
-    tableRows
+    tableRows,
   });
 });
-
 
 export default router;

--- a/src/stylesheets/_expander.scss
+++ b/src/stylesheets/_expander.scss
@@ -1,5 +1,5 @@
 .app-c-expander {
-  padding: 0 0 govuk-spacing(2);
+  padding: 0 0 govuk-spacing(2) 0;
   margin-bottom: govuk-spacing(2);
   border-bottom: 1px solid $govuk-border-colour;
   &:last-child {
@@ -23,7 +23,7 @@
 .js-enabled {
   .app-c-expander__heading {
     position: relative;
-    padding: 10px 8px 5px 43px;
+    padding: 10px 8px 14px 50px;
     margin: 0;
   }
 

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -50,6 +50,8 @@ aside {
   }
 }
 
-#declarationForm {
+#declarationForm,
+#legalPowerAdviceForm,
+#legalGatewayAdviceForm {
   margin-top: govuk-spacing(8);
 }

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -25,7 +25,8 @@
     }
   }
 }
-.add-another__organisation:first-of-type {
+.add-another__organisation:first-of-type,
+.add-another__country:first-of-type {
   margin-bottom: govuk-spacing(5);
 }
 aside {

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -44,12 +44,6 @@ aside {
   margin-bottom: govuk-spacing(9);
 }
 
-.govuk-table > tbody > tr {
-  td:first-of-type {
-    width: 10%;
-  }
-}
-
 #declarationForm,
 #legalPowerAdviceForm,
 #legalGatewayAdviceForm {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -147,7 +147,7 @@ type LawfulBasisSpecialPublicInterestStep = {
   standards?: LawfulBasis;
 };
 
-type MoreOrganisationStep = string[];
+type GenericStringArray = string[];
 
 type FormStatus =
   | "NOT STARTED"
@@ -158,7 +158,7 @@ type FormStatus =
 
 export type StepValue =
   | string
-  | MoreOrganisationStep
+  | GenericStringArray
   | DataTypeStep
   | ProjectAimStep
   | BenefitsStep

--- a/src/views/acquirer/benefits.njk
+++ b/src/views/acquirer/benefits.njk
@@ -13,9 +13,10 @@
             {{ govukTextarea({
             id: "decision-making",
             name: "decision-making",
+            rows: 3,
             label: {
-    text: "How will your project do this?"
-  },
+                text: "How will your project do this?"
+            },
             value: savedValue['decision-making']['explanation']
             }) }}
         {% endset -%}
@@ -24,6 +25,7 @@
             {{ govukTextarea({
             id: "service-delivery",
             name: "service-delivery",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -35,6 +37,7 @@
             {{ govukTextarea({
             id: "benefit-people",
             name: "benefit-people",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -46,6 +49,7 @@
             {{ govukTextarea({
             id: "allocate-and-evaluate-funding",
             name: "allocate-and-evaluate-funding",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -57,6 +61,7 @@
             {{ govukTextarea({
             id: "social-economic-trends",
             name: "social-economic-trends",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -69,6 +74,7 @@
             {{ govukTextarea({
             id: "needs-of-the-public",
             name: "needs-of-the-public",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -80,6 +86,7 @@
             {{ govukTextarea({
             id: "statistical-information",
             name: "statistical-information",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -91,6 +98,7 @@
             {{ govukTextarea({
             id: "existing-research-or-statistics",
             name: "existing-research-or-statistics",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },
@@ -102,6 +110,7 @@
             {{ govukTextarea({
             id: "something-else",
             name: "something-else",
+            rows: 3,
             label: {
             text: "How will your project do this?"
             },

--- a/src/views/acquirer/data-required.njk
+++ b/src/views/acquirer/data-required.njk
@@ -12,7 +12,7 @@
       {{ govukTextarea({
         id: "data-required",
         name: "data-required",
-        html: dataSubjectDetails,
+        text: dataSubjectDetails,
         rows: 5,
         value: savedValue
       }) }}

--- a/src/views/acquirer/data-required.njk
+++ b/src/views/acquirer/data-required.njk
@@ -12,7 +12,6 @@
       {{ govukTextarea({
         id: "data-required",
         name: "data-required",
-        text: dataSubjectDetails,
         rows: 5,
         value: savedValue
       }) }}

--- a/src/views/acquirer/data-required.njk
+++ b/src/views/acquirer/data-required.njk
@@ -6,18 +6,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+    <label for="data-required" class="govuk-label govuk-label--l">What data from + {{assetTitle}} + do you need?</label>
+    <p class="govuk-body"><a class="govuk-link" href="#" target="_blank"> View data (opens in new tab)</a></p>
     <form method="post">
       {{ govukTextarea({
-            id: "data-required",
-            name: "data-required",
-            label: {
-                text: "What data from " + assetTitle + " do you need?",
-                isPageHeading: true,
-                classes: "govuk-label--l"
-            },
-            rows: 5,
-            value: savedValue
-            }) }}
+        id: "data-required",
+        name: "data-required",
+        html: dataSubjectDetails,
+        rows: 5,
+        value: savedValue
+      }) }}
       <div class="govuk-button-group">
         {{ govukButton({
             text: "Save and continue",

--- a/src/views/acquirer/data-required.njk
+++ b/src/views/acquirer/data-required.njk
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Request ID: {{requestId}}</span>
-    <label for="data-required" class="govuk-label govuk-label--l">What data from + {{assetTitle}} + do you need?</label>
+    <label for="data-required" class="govuk-label govuk-label--l">What data from {{ assetTitle }} do you need?</label>
     <p class="govuk-body"><a class="govuk-link" href="#" target="_blank"> View data (opens in new tab)</a></p>
     <form method="post">
       {{ govukTextarea({

--- a/src/views/acquirer/data-subjects.njk
+++ b/src/views/acquirer/data-subjects.njk
@@ -7,21 +7,33 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+   
       <form action="/acquirer/{{assetId}}/{{stepId}}" method="POST" id="dataTypeForm">
+        <label class="govuk-label govuk-label--l" for="data-subjects">
+          Who are the data subjects?
+        </label>
+        <div id="data-subjects-hint" class="govuk-hint">
+          Be as specific as possible. For example, small business owners aged between 45 and 55.
+        </div>
+        {% set dataSubjectDetails %}
+          <p class="govuk-body">Data subjects are the people whose data you are requesting.</p>
+          <p class="govuk-body">For example:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><p>Small business owners aged between 45 and 55.</p></li>
+            <li><p>All people using Universal Credit with children.</p></li>
+          </ul>
+          <p class="govuk-body">Data subjects should be specific to the purpose of your data request.</p>
+        {% endset %}
+        {{ govukDetails({
+          summaryText: "Data subject definition and examples",
+          html: dataSubjectDetails
+        }) }}
         {{ govukTextarea({
-                    name: "data-subjects",
-                    id: "data-subjects",
-                    label: {
-                      text: "Who are the data subjects?",
-                      classes: "govuk-label--l",
-                      isPageHeading: true
-                    },
-                    rows: 4,
-                    value: savedValue,
-                    hint: {
-                      html: "Be as specific as possible. For example, small business owners aged between 45 and 55."
-                    }
-                  }) }}
+          name: "data-subjects",
+          id: "data-subjects",
+          rows: 5,
+          value: savedValue
+        }) }}
         <div class="govuk-button-group">
         {{ govukButton({
             text: "Save and continue",

--- a/src/views/acquirer/data-travel-location.njk
+++ b/src/views/acquirer/data-travel-location.njk
@@ -1,31 +1,72 @@
 {% extends "page.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block content %}
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <form method="post">
-      {{ govukInput({
-            id: "data-travel-location",
-            name: "data-travel-location",
-            label: {
-                text: "What countries will the data travel through?",
-                classes: "govuk-label--m"
-            },
-            value: savedValue
-            }) }}
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+<h1 class="govuk-heading-l govuk-fieldset__legend govuk-fieldset__legend--l">What countries will the data travel through?</h1>
+      <form method="POST" id="dataTravelLocationForm">
+        {% for country in savedValue %}
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              {% call govukFieldset({
+              classes: "add-another__country" ,
+              legend: {
+                classes: 'govuk-fieldset__legend--m',
+                isPageHeading: false
+              }
+              }) %}
+                {{ govukInput({
+                  id: "country-name-" + loop.index,
+                  name: "country-name-" + loop.index,
+                  value: country,
+                  classes: "govuk-input--width-20",
+                  attributes: {
+                    'data-name': 'countries[' + loop.index + ']',
+                    'data-id': 'countries[' + loop.index + ']'
+                  }
+                }) }}
+              {% endcall %}
+            </div>
+            
+            {# Only show the remove button if it's not the first input #}
+            {% if loop.index > 1 %}
+              <div class="govuk-grid-column-one-third">
+                <p class="govuk-body">
+                  {{ govukButton({
+                    text: "Remove",
+                    name: "removeCountry",
+                    classes: "govuk-button govuk-button--secondary",
+                    value: loop.index
+                  }) }}
+                </p>
+              </div>
+            {% endif %}
+          </div>
+        {% endfor %}
+
+      <p class="govuk-body">
+        {{ govukButton({
+          text: "Add another country",
+          name: "addCountry",
+          classes: "govuk-button--secondary",
+          value: "true"
+        }) }}
+      </p>
       <div class="govuk-button-group">
         {{ govukButton({
-            text: "Save and continue",
-            name: "continueButton",
-            value: "continue"
+          text: "Save and continue",
+          name: "continueButton",
+          value: "continue"
         }) }}
         {{ govukButton({
-            text: "Save and return",
-            classes: "govuk-button--secondary",
-            name: "returnButton",
-            value: "return"
+          text: "Save and return",
+          classes: "govuk-button--secondary",
+          name: "returnButton",
+          value: "return"
         }) }}
       </div>
     </form>

--- a/src/views/acquirer/delivery.njk
+++ b/src/views/acquirer/delivery.njk
@@ -9,54 +9,55 @@
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="dataDeliveryForm">
          {% set somethingHTML %}
-            {{ govukInput({
+          {{ govukInput({
             id: "something-else",
             name: "something-else",
+            classes: "govuk-!-width-two-thirds",
             value: savedValue['something']['explanation']
-            }) }}
+          }) }}
         {% endset -%}
         {{ govukRadios({
-                 name: "delivery",
-                  fieldset: {
-                      legend: {
-                      text: "How would you like to receive the data?",
-                      isPageHeading: true,
-                      classes: "govuk-fieldset__legend--l"
-                      }
-                  },
-                  items: [
-                      {
-                      value: "third-party",
-                      text: "Through secure third-party software",
-                      checked: savedValue['third-party']['checked']
-                      },
-                      {
-                      value: "physical",
-                      text: "Physical delivery",
-                      checked: savedValue['physical']['checked']
-                      },
-                      {
-                      value: "something",
-                      text: "Something else",
-                      checked: savedValue['something']['checked'],
-                    conditional: {
-                        html: somethingHTML
-                }
-                                      }
-                  ]
-                  }) }}
-          <div class="govuk-button-group">
-            {{ govukButton({
-                text: "Save and continue",
-                name: "continueButton",
-                value: "continue"
-            }) }}
-            {{ govukButton({
-                text: "Save and return",
-                classes: "govuk-button--secondary",
-                name: "returnButton",
-                value: "return"
-            }) }}
+          name: "delivery",
+          fieldset: {
+              legend: {
+              text: "How would you like to receive the data?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+              }
+          },
+          items: [
+              {
+              value: "third-party",
+              text: "Through secure third-party software",
+              checked: savedValue['third-party']['checked']
+              },
+              {
+              value: "physical",
+              text: "Physical delivery",
+              checked: savedValue['physical']['checked']
+              },
+              {
+              value: "something",
+              text: "Something else",
+              checked: savedValue['something']['checked'],
+            conditional: {
+                html: somethingHTML
+              }
+            }
+          ]
+          }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+              text: "Save and continue",
+              name: "continueButton",
+              value: "continue"
+          }) }}
+          {{ govukButton({
+              text: "Save and return",
+              classes: "govuk-button--secondary",
+              name: "returnButton",
+              value: "return"
+          }) }}
         </div>
       </form>
     </div>

--- a/src/views/acquirer/format.njk
+++ b/src/views/acquirer/format.njk
@@ -4,61 +4,62 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Request ID: {{requestId}}</span>
-      <form method="POST" id="dataFormatForm">
-         {% set somethingHTML %}
-            {{ govukInput({
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: {{requestId}}</span>
+    <form method="POST" id="dataFormatForm">
+        {% set somethingHTML %}
+          {{ govukInput({
             id: "something-else",
             name: "something-else",
+            classes: "govuk-!-width-two-thirds",
             value: savedValue['something']['explanation']
-            }) }}
+          }) }}
         {% endset -%}
         {{ govukRadios({
-                 name: "format",
-                  fieldset: {
-                      legend: {
-                      text: "What is your preferred format for this data?",
-                      isPageHeading: true,
-                      classes: "govuk-fieldset__legend--l"
-                      }
-                  },
-                  items: [
-                      {
-                      value: "csv",
-                      text: "CSV file",
-                      checked: savedValue['csv']['checked']
-                      },
-                      {
-                      value: "sql",
-                      text: "SQL dataset",
-                      checked: savedValue['sql']['checked']
-                      },
-                      {
-                      value: "something",
-                      text: "Something else",
-                      checked: savedValue['something']['checked'],
-                    conditional: {
-                        html: somethingHTML
-                }
-                                      }
-                  ]
-                  }) }}
-          <div class="govuk-button-group">
-            {{ govukButton({
-                text: "Save and continue",
-                name: "continueButton",
-                value: "continue"
-            }) }}
-            {{ govukButton({
-                text: "Save and return",
-                classes: "govuk-button--secondary",
-                name: "returnButton",
-                value: "return"
-            }) }}
-        </div>
-      </form>
-    </div>
+          name: "format",
+          fieldset: {
+              legend: {
+              text: "What is your preferred format for this data?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+              }
+          },
+          items: [
+              {
+              value: "csv",
+              text: "CSV file",
+              checked: savedValue['csv']['checked']
+              },
+              {
+              value: "sql",
+              text: "SQL dataset",
+              checked: savedValue['sql']['checked']
+              },
+              {
+              value: "something",
+              text: "Something else",
+              checked: savedValue['something']['checked'],
+            conditional: {
+                html: somethingHTML
+            }
+          }
+        ]
+        }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+              text: "Save and continue",
+              name: "continueButton",
+              value: "continue"
+          }) }}
+          {{ govukButton({
+              text: "Save and return",
+              classes: "govuk-button--secondary",
+              name: "returnButton",
+              value: "return"
+          }) }}
+      </div>
+    </form>
   </div>
+</div>
 {% endblock %}

--- a/src/views/acquirer/lawful-basis-personal.njk
+++ b/src/views/acquirer/lawful-basis-personal.njk
@@ -12,7 +12,7 @@
           <p class="govuk-body">Find out more about having a 
             <a target="_blank" class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/">
             lawful basis for processing personal data (opens in new tab).</a>
-          <p class="govuk-body">You may need help from a data protection specialist.</p>
+          <p class="govuk-caption">You may need help from a data protection specialist.</p>
         </div>
         {% endset %}
         {{ govukCheckboxes({

--- a/src/views/acquirer/legal-power.njk
+++ b/src/views/acquirer/legal-power.njk
@@ -1,5 +1,5 @@
 {% extends "page.njk" %}
-{%- from "govuk/components/textarea/macro.njk" import govukTextarea -%}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
@@ -9,12 +9,13 @@
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <form method="POST" id="legalPowerForm">
         {% set legalPowerDecision %}
-            {{ govukTextarea({
+            {{ govukInput({
                 id: "legal-power-textarea",
                 name: "legal-power-textarea",
                 label: {
                     text: "What legal power will you use?"
                 },
+                classes: "govuk-!-width-one-half",
                 value: savedValue['yes']['explanation']
             }) }}
         {% endset -%}


### PR DESCRIPTION
The biggest change in this PR is implementing the functionality in `data-travel-location` if the user selects `Yes, it will leave the UK` on the `data-travel page` to add additional countries as the prototype suggests, this functionality is exactly the same as the "other-orgs" page, where the user is able to add additional strings into an array.
can be seen here [picture of data-travel-location](https://gyazo.com/3bf39e75b3d265652fc6ddab36670d83)

Also instead of creating another type of string[] for `data-travel-location` StepValue I instead changed the `MoreOrganisationStep` type to GenericStringArray and used this generic type for both `other-orgs` and `data-travel-location` steps.

I have gone and implemented these things:

increased padding under filter options within the `find` page
reduced row count for each benefit textArea
as previously mentioned, add additional country functionality to `data-travel-location` page
added form id's to styles for additional padding on `legal-power-advice` and `legal-gateway-advice` pages
added missing anchor `"View data (opens in new tab)"` in `data-required` page

