### PR TITLE
DMBM-78 - Explore by Theme

### DIFF
--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -108,32 +108,29 @@ describe("fetchResources", () => {
     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
 
-///
 
-
-
-it("should return filtered data when one theme filter is provided", async () => {
-  const themeFilter = "Transport";
+  it("should return filtered data when one theme filter is provided", async () => {
+    const themeFilter = "Transport";
+      
+    const expectedData = mockData.data.filter((resource) => {
+      return resource.theme.includes(themeFilter);
+    });
     
-  const expectedData = mockData.data.filter((resource) => {
-    return resource.theme.includes(themeFilter);
+    const result = await fetchResources(undefined, undefined, [themeFilter]);
+    expect(result.resources).toEqual(expectedData); 
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
-  
-  const result = await fetchResources(undefined, undefined, [themeFilter]);
-  expect(result.resources).toEqual(expectedData); 
-  expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-});
 
-it("should return filtered data when two theme filters are provided", async () => {
-  const themeFilters = ["Transport", "Mapping"];
+  it("should return filtered data when two theme filters are provided", async () => {
+    const themeFilters = ["Transport", "Mapping"];
 
-  const expectedData = mockData.data.filter(resource => {
-    return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
-  });
-  
-  const result = await fetchResources(undefined, undefined, themeFilters);
-  expect(result.resources).toEqual(expectedData);
-  expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+    const expectedData = mockData.data.filter(resource => {
+      return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
+    });
+    
+    const result = await fetchResources(undefined, undefined, themeFilters);
+    expect(result.resources).toEqual(expectedData);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
 
 
@@ -195,28 +192,26 @@ it("should return filtered data when two theme filters are provided", async () =
     expect(result.resources).toEqual(expectedData);
     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
-  
-  it("should return filtered data when organisation filters and theme filters are provided (no query)", async () => {
-    const organisationFilters = ["department-for-test"];
-    const themeFilters = ["Transport"];
-  
+
+  it("should return no data when neither the query nor the organisation filter nor the theme filter matches", async () => {
+    const query = "nonexistentquery";
+    const organisationFilters = "non-existent-theme";
+    const themeFilters = ["nonexistent-organisation"];
     const expectedData = mockData.data.filter((resource) => {
-      const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
-      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
-  
-      return matchesOrgFilter && matchesThemeFilter;
+        const matchesQuery = Object.values(resource).some(
+            (value) => value?.toString().toLowerCase().includes(query)
+        );
+        const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilters.toLowerCase();
+        const matchesThemeFilter = resource.theme === themeFilters;
+
+        return matchesQuery || matchesThemeFilter || matchesOrgFilter;
     });
-  
-    const result = await fetchResources(undefined, organisationFilters, themeFilters);
+    expect(expectedData.length).toBe(0);
+
+    const result = await fetchResources(query, undefined, themeFilters);
     expect(result.resources).toEqual(expectedData);
     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
   });
-  
-
-
-
-
-
 
   it("should throw an error when the axios request fails", async () => {
     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));

--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -3,6 +3,10 @@ import { fetchResources, fetchResourceById } from "../src/services/findService";
 import mockData from "./mock/mockData.json";
 import singleMockData from "./mock/singleMockData.json";
 
+// Add dotenv config to test suite
+import dotenv from 'dotenv';
+dotenv.config();
+
 // Mock axios get function
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -102,7 +106,117 @@ describe("fetchResources", () => {
     const result = await fetchResources(query, [organisationFilter]);
     expect(result.resources).toEqual(expectedData);
     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+
+///
+
+
+
+it("should return filtered data when one theme filter is provided", async () => {
+  const themeFilter = "Transport";
+    
+  const expectedData = mockData.data.filter((resource) => {
+    return resource.theme.includes(themeFilter);
+  });
+  
+  const result = await fetchResources(undefined, undefined, [themeFilter]);
+  expect(result.resources).toEqual(expectedData); 
+  expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
 });
+
+it("should return filtered data when two theme filters are provided", async () => {
+  const themeFilters = ["Transport", "Mapping"];
+
+  const expectedData = mockData.data.filter(resource => {
+    return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
+  });
+  
+  const result = await fetchResources(undefined, undefined, themeFilters);
+  expect(result.resources).toEqual(expectedData);
+  expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+
+
+  it("should return filtered data when both a query and a theme filter are provided", async () => {
+    const query = "test service";
+    const themeFilters = ["Transport"];
+  
+    const expectedData = mockData.data.filter((resource) => {
+      const matchesQuery = Object.values(resource).some(
+        (value) => value?.toString().toLowerCase().includes(query)
+      );
+  
+      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
+  
+      return matchesQuery && matchesThemeFilter;
+    });
+  
+    const result = await fetchResources(query, undefined, themeFilters);
+    expect(result.resources).toEqual(expectedData);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+  
+
+  it("should return no data when neither the query nor the theme filter matches", async () => {
+    const query = "nonexistentquery";
+    const themeFilters = ["nonexistent-organisation"];
+    const expectedData = mockData.data.filter((resource) => {
+        const matchesQuery = Object.values(resource).some(
+            (value) => value?.toString().toLowerCase().includes(query)
+        );
+        const matchesThemeFilter = resource.theme === themeFilters;
+
+        return matchesQuery || matchesThemeFilter;
+    });
+    expect(expectedData.length).toBe(0);
+
+    const result = await fetchResources(query, undefined, themeFilters);
+    expect(result.resources).toEqual(expectedData);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+
+  it("should return filtered data when both query, organisation filters, and theme filters are provided", async () => {
+    const query = "test service";
+    const organisationFilters = ["department-for-test"];
+    const themeFilters = ["Transport"];
+  
+    const expectedData = mockData.data.filter((resource) => {
+      const matchesQuery = Object.values(resource).some(
+        (value) => value?.toString().toLowerCase().includes(query)
+      );
+  
+      const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
+      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
+  
+      return matchesQuery && matchesOrgFilter && matchesThemeFilter;
+    });
+  
+    const result = await fetchResources(query, organisationFilters, themeFilters);
+    expect(result.resources).toEqual(expectedData);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+  
+  it("should return filtered data when organisation filters and theme filters are provided (no query)", async () => {
+    const organisationFilters = ["department-for-test"];
+    const themeFilters = ["Transport"];
+  
+    const expectedData = mockData.data.filter((resource) => {
+      const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
+      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
+  
+      return matchesOrgFilter && matchesThemeFilter;
+    });
+  
+    const result = await fetchResources(undefined, organisationFilters, themeFilters);
+    expect(result.resources).toEqual(expectedData);
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+  });
+  
+
+
+
+
+
 
   it("should throw an error when the axios request fails", async () => {
     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));

--- a/__tests__/mock/mockData.json
+++ b/__tests__/mock/mockData.json
@@ -45,7 +45,7 @@
       "serviceType": "SOAP",
       "summary": "Test summary for displaying the summary",
       "theme": [
-        "https://www.test.com"
+        "Transport"
       ],
       "title": "Test Service",
       "type": "DataService",
@@ -98,7 +98,7 @@
       "serviceType": "REST",
       "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam gravida sagittis arcu.",
       "theme": [
-        "https://www.tests.test.uk/search?filters%5Btopic%5D=test"
+        "Mapping"
       ],
       "title": "Test Service for Testing",
       "type": "DataService",

--- a/__tests__/mock/singleMockData.json
+++ b/__tests__/mock/singleMockData.json
@@ -45,7 +45,7 @@
       "serviceType": "SOAP",
       "summary": "Test summary for displaying the summary",
       "theme": [
-        "https://www.test.com"
+        "Transport"
       ],
       "title": "Test Service",
       "type": "DataService",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digital-marketplace",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digital-marketplace",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "ISC",
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.2",

--- a/src/mockData/themes.ts
+++ b/src/mockData/themes.ts
@@ -1,0 +1,16 @@
+export const themes = [
+  "Business and economy",
+  "Crime and justice",
+  "Defence",
+  "Digital service performance",
+  "Education",
+  "Environment",
+  "Government",
+  "Government reference data",
+  "Government spending",
+  "Health",
+  "Mapping",
+  "Society",
+  "Towns and cities",
+  "Transport",
+];

--- a/src/routes/findRoutes.ts
+++ b/src/routes/findRoutes.ts
@@ -5,21 +5,27 @@ import {
   fetchResourceById,
   fetchOrganisations,
 } from "../services/findService";
+import { themes } from "../mockData/themes";
 
 router.get("/", async (req: Request, res: Response, next: NextFunction) => {
   const backLink = req.session.backLink || "/";
   req.session.backLink = req.originalUrl;
-  // Extract the 'q' query parameter from the request, convert it to a string,
-  // change it to lowercase for case insensitive search, and assign it to the 'query' variable.
-  // If 'q' doesn't exist, assign 'undefined' to the 'query' variable.
   const query: string | undefined = (req.query.q as string)?.toLowerCase();
   const organisationFilters: string[] | undefined = req.query
     .organisationFilters as string[] | undefined;
+  const themeFilters: string[] | undefined = req.query.themeFilters as
+    | string[]
+    | undefined;
 
   try {
     // Fetch the data from the API
-    const { resources } = await fetchResources(query, organisationFilters);
+    const { resources } = await fetchResources(
+      query,
+      organisationFilters,
+      themeFilters,
+    );
     const organisations = await fetchOrganisations();
+    const themesList = themes;
     const filterOptions = [
       // Define the shape of "filterOptions", add more as needed
       {
@@ -40,10 +46,24 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
               : "",
         })),
       },
+      {
+        id: "themeFilters",
+        name: "themeFilters",
+        title: "Themes",
+        items: themesList.map((theme) => ({
+          value: theme,
+          text: theme,
+          checked:
+            (Array.isArray(themeFilters) && themeFilters.includes(theme)) ||
+            (typeof themeFilters === "string" && themeFilters === theme)
+              ? "checked"
+              : "",
+        })),
+      },
       // more filters here
     ];
 
-    // Create filterOptionTags based on the selected filters in organisationFilters
+    // Create filterOptionTags based on the selected filters in organisationFilters and themeFilters
     const filterOptionTags = [
       {
         id: "organisationFilters",
@@ -53,6 +73,17 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
           .map((org) => ({
             value: org.slug,
             text: org.title,
+            checked: "checked",
+          })),
+      },
+      {
+        id: "themeFilters",
+        title: "Themes",
+        items: themesList
+          .filter((theme) => themeFilters?.includes(theme))
+          .map((theme) => ({
+            value: theme,
+            text: theme,
             checked: "checked",
           })),
       },

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -10,10 +10,12 @@ import { getLicenceTitleFromURL } from "../helperFunctions/helperFunctions";
 export async function fetchResources(
   query?: string,
   organisationFilters?: string[],
+  themeFilters?: string[],
   filterOptionTags?: string[],
 ): Promise<{
   resources: CatalogueItem[];
   uniqueOrganisations: Organisation[];
+  uniqueThemes: string[];
   selectedFilters?: string[];
 }> {
   const apiUrl = `${process.env.API_ENDPOINT}/catalogue`;
@@ -43,6 +45,20 @@ export async function fetchResources(
     }
   });
 
+  // Extract unique themes
+  const themesSet = new Set<string>();
+  const uniqueThemes: string[] = [];
+  resources.forEach((item) => {
+    if (item.theme && Array.isArray(item.theme)) {
+      item.theme.forEach((theme) => {
+        if (!themesSet.has(theme)) {
+          uniqueThemes.push(theme);
+          themesSet.add(theme);
+        }
+      });
+    }
+  });
+
   if (organisationFilters) {
     resources = resources.filter(
       (item) =>
@@ -51,12 +67,21 @@ export async function fetchResources(
     );
   }
 
+  if (themeFilters) {
+    resources = resources.filter(
+      (item) =>
+        item.theme && item.theme.some((theme) => themeFilters.includes(theme)),
+    );
+  }
+
   return {
     resources: resources,
     uniqueOrganisations: uniqueOrganisations,
+    uniqueThemes: uniqueThemes,
     selectedFilters: filterOptionTags,
   };
 }
+
 export async function fetchResourceById(
   resourceID: string,
 ): Promise<CatalogueItem> {

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -47,18 +47,14 @@ export async function fetchResources(
 
   // Extract unique themes
   const themesSet = new Set<string>();
-  const uniqueThemes: string[] = [];
   resources.forEach((item) => {
     if (item.theme && Array.isArray(item.theme)) {
       item.theme.forEach((theme) => {
-        if (!themesSet.has(theme)) {
-          uniqueThemes.push(theme);
           themesSet.add(theme);
-        }
       });
     }
   });
-
+  const uniqueThemes = Array.from(themesSet)
   if (organisationFilters) {
     resources = resources.filter(
       (item) =>

--- a/src/views/find.njk
+++ b/src/views/find.njk
@@ -71,7 +71,7 @@
             </div>
             {% if hasFilters %}
                 <div id="js-facet-tag-wrapper" class="facet-tags__container facet-tags__container--hidden" aria-live="assertive">
-                    <a id="clear-filters" class="govuk-link govuk-link--no-visited-state" href="{{assetpath}}/find">
+                    <a id="clear-filters" class="govuk-link govuk-link--no-visited-state" href="{{assetpath}}/find{% if query %}?q={{ query }}{% endif %}">
                         <span>Clear Filters</span>
                     </a>
                     {% for category in filterOptionTags %}


### PR DESCRIPTION
This PR implements filtering by theme on the search results page by building on the existing implementation of filtering by organisation. There is a hardcoded list of available themes to filter by which are taken from the topic filters on [data.gov.uk](data.gov.uk). The theme filters work in combination with the organisation filters and the search query to display relevant resources. 

I added additional test coverage to test the theme filters with and without combinations with the query and organisation filters.  The [API](https://github.com/co-cddo/data-marketplace-api) we are calling returns an array of strings for the themes which were initially in the format of a URI, however this has now been changed to a readable label instead. The mock data has since been updated to reflect the API's update. I also added the dotenv configuration to the find test file so that the environment variables are passed to the tests.

Additionally, the clear filters button has been adjusted so that if it is clicked, it retains the search query (if there is one). 