### PR TITLE
First implementation of review-summary (UI)

### DIFF
--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -59,5 +59,21 @@ router.get("/created-requests", async (req: Request, res: Response) => {
   });
 });
 
+router.get("/received-requests", async (req: Request, res: Response) => {
+  const backLink = req.headers.referer || "/";
+  res.render("../views/supplier/received-requests.njk", {
+    backLink,
+  });
+});
+
+router.get("/review-summary", async (req: Request, res: Response) => {
+  const backLink = req.headers.referer || "/";
+  const acquirerForms = req.session.acquirerForms || {};
+
+  res.render("../views/supplier/review-summary.njk", {
+    backLink,
+    acquirerForms
+  });
+});
 
 export default router;

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -46,6 +46,22 @@ aside {
 
 #declarationForm,
 #legalPowerAdviceForm,
-#legalGatewayAdviceForm {
+#legalGatewayAdviceForm
+{
   margin-top: govuk-spacing(8);
+}
+
+#reviewSummaryForm {
+  margin-top: govuk-spacing(6);
+}
+
+.govuk-warning-text__icon
+{
+  color: #666;
+  background-color: #ffff;
+  border-color: #666;
+}
+
+.govuk-warning-text {
+  margin-bottom: govuk-spacing(2);
 }

--- a/src/views/supplier/received-requests.njk
+++ b/src/views/supplier/received-requests.njk
@@ -48,7 +48,7 @@
             rows: [
             [
                 {
-                html: '<a href="#" class="govuk-link">RR523 - View</a>'
+                html: '<a href="/manage-shares/review-summary" class="govuk-link">RR523 - View</a>'
                 },
                 {
                 text: "Department X"

--- a/src/views/supplier/review-summary.njk
+++ b/src/views/supplier/review-summary.njk
@@ -1,0 +1,59 @@
+{% extends "page.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: RR523</span>
+    <h1 class="govuk-heading-l">Department X is requesting access to access citizen-relationships data</h1>
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
+    <p class="govuk-body">To assess claims and provide the correct level of support to vulnerable people based on their declared family relationships.</p>
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
+    <p class="govuk-body">8 July 2023</p>
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
+    <p class="govuk-body"><a href="#" class="govuk-link">data-team@department-x.gov.uk</a></p>
+
+    {{ govukWarningText({
+      text: "Request not reviewed by Legal.",
+      iconFallbackText: "Warning"
+    }) }}
+
+    {{ govukWarningText({
+      text: "Data will travel outside UK.",
+      iconFallbackText: "Warning"
+    }) }}
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+          text: "Continue",
+          name: "continueButton",
+          value: "continue"
+      }) }}
+      <a href="/manage-shares/received-requests" class="govuk-link">Returned to received requests</a>
+    </div>
+
+    <h2 class="govuk-heading-m">More information</h2>
+
+    {% set detailsContent %}
+    <p>You're about to review a data share request. You'll need to decide if it meets your requirements so you can draft a data sharing agreement with Department X.</p>
+    <p>When you've reviewed the request, you can choose to:</p>
+    <ul>
+        <li>Accept the data share request</li>
+        <li>Reject the data share request</li>
+        <li>Return with comments</li>
+    </ul>
+    {% endset %}
+    {{ govukDetails({
+        summaryText: "Your decision options",
+        text: detailsContent  | safe
+    }) }}
+  </div>
+</div>
+{% endblock %}

--- a/src/views/supplier/review-summary.njk
+++ b/src/views/supplier/review-summary.njk
@@ -10,44 +10,38 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Request ID: RR523</span>
     <h1 class="govuk-heading-l">Department X is requesting access to access citizen-relationships data</h1>
-
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
     <p class="govuk-body">To assess claims and provide the correct level of support to vulnerable people based on their declared family relationships.</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Received</h2>
     <p class="govuk-body">8 July 2023</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Contact</h2>
     <p class="govuk-body"><a href="#" class="govuk-link">data-team@department-x.gov.uk</a></p>
-
     {{ govukWarningText({
       text: "Request not reviewed by Legal.",
       iconFallbackText: "Warning"
     }) }}
-
     {{ govukWarningText({
       text: "Data will travel outside UK.",
       iconFallbackText: "Warning"
     }) }}
-
-    <div class="govuk-button-group">
-      {{ govukButton({
-          text: "Continue",
-          name: "continueButton",
-          value: "continue"
-      }) }}
-      <a href="/manage-shares/received-requests" class="govuk-link">Returned to received requests</a>
-    </div>
-
+    <form action="POST" id="reviewSummaryForm">
+      <div class="govuk-button-group">
+        {{ govukButton({
+            text: "Continue",
+            name: "continueButton",
+            value: "continue"
+        }) }}
+        <a href="/manage-shares/received-requests" class="govuk-link">Returned to received requests</a>
+      </div>
+    </form>
     <h2 class="govuk-heading-m">More information</h2>
-
     {% set detailsContent %}
     <p>You're about to review a data share request. You'll need to decide if it meets your requirements so you can draft a data sharing agreement with Department X.</p>
     <p>When you've reviewed the request, you can choose to:</p>
     <ul>
-        <li>Accept the data share request</li>
-        <li>Reject the data share request</li>
-        <li>Return with comments</li>
+      <li>Accept the data share request</li>
+      <li>Reject the data share request</li>
+      <li>Return with comments</li>
     </ul>
     {% endset %}
     {{ govukDetails({


### PR DESCRIPTION
Implemented the review-summary page. 

This is the same as the prototype, we can click the initial request id here:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/e849de71-72f0-4245-8d34-b890ce9bad6e)

which takes us to the review-summary page:

![image](https://github.com/co-cddo/data-marketplace/assets/71328022/9ff4fa97-4972-436b-ac8e-ce066f47db4d)
