### PR TITLE
Check page: lawful basis items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-marketplace",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "imagename": "dm-frontend",
   "description": "",
   "main": "index.js",

--- a/src/helperFunctions/helperFunctions.ts
+++ b/src/helperFunctions/helperFunctions.ts
@@ -582,11 +582,11 @@ function checkAnswer(formdata: FormData) {
           for (const [answerId, answerVal] of Object.entries(stepData.value)) {
             const explanation = answerVal.explanation || "";
             if (answerVal.checked) {
-              dataTypeValue.push(replace[stepId].data[answerId]);
+              dataTypeValue.push(`${replace[stepId].data[answerId]}<br/>`);
             }
             if (explanation) {
               dataTypeValue.push(
-                `<br/><p class="govuk-body-s caption-color">${explanation}</p>`,
+                `<p class="govuk-body-s caption-color">${explanation}</p>`,
               );
             }
             // Do something slightly different for the public interest answers


### PR DESCRIPTION
# Bugfix: Lawful basis items
This PR fixes a bug found by @AShaww where if you tick several of the "lawful basis" checkboxes they all end up on the same line on the Check Page:
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/53f6939a-fcb8-466e-9262-1abe6a8976b3)

## Changes
Added a line break in between checkbox items.
The page now looks like this:
![localhost_3000_acquirer_fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1_check (1)](https://github.com/co-cddo/data-marketplace/assets/1217533/3892a68d-079c-4a33-a80b-7ea73412226d)
