### PR TITLE
Update tsconfig.json with commonjs module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ESNext"],
     "outDir": "build",
     "moduleResolution": "node",
+    "module": "commonjs",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "src/types"]


### PR DESCRIPTION
It's unclear why, but on linux systems we were seeing a build error relating to the default value of "module" being node16 instead of commonjs. This change resolves it by explicitly setting the module. I can't say I know exactly what the module configuration does, but the fix works.