### PR TITLE
add request accept page

### DIFF
--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -94,6 +94,15 @@ router.get("/review-summary", async (req: Request, res: Response) => {
   });
 });
 
+router.get("/request-accepted", async (req: Request, res: Response) => {
+  const backLink = req.headers.referer || "/";
+  const acquirerForms = req.session.acquirerForms || {};
+  res.render("../views/supplier/request-accepted.njk", {
+    backLink,
+    acquirerForms,
+  });
+});
+
 router.post("/review-summary", async (req: Request, res: Response) => {
   if (req.body.continueButton) {
     return res.redirect("/manage-shares/review-request");

--- a/src/views/supplier/received-requests.njk
+++ b/src/views/supplier/received-requests.njk
@@ -147,7 +147,7 @@
         rows: [
         [
             {
-                html: '<a href="#" class="govuk-link">RR147 - View</a>'
+                html: '<a href="/manage-shares/request-accepted" class="govuk-link">RR147 - View</a>'
             },
             {
             text: "Department for Education"

--- a/src/views/supplier/request-accepted.njk
+++ b/src/views/supplier/request-accepted.njk
@@ -24,7 +24,7 @@
 
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
     <p class="govuk-body">The Department for Education have been told that this request was accepted.</p>
-    <p class="govuk-body">Contact <a href="#1">data-management@dfe.gov.uk</a> to set up the data share arrangement.</p>
+    <p class="govuk-body">Contact <a href="#1" class="govuk-link">data-management@dfe.gov.uk</a> to set up the data share arrangement.</p>
   </div>
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Requested by</h2>

--- a/src/views/supplier/request-accepted.njk
+++ b/src/views/supplier/request-accepted.njk
@@ -1,0 +1,57 @@
+{% extends "page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Request ID: RR147</span>
+    <h1 class="govuk-heading-xl">
+      Accepted request
+    </h1>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Decision made</h2>
+    <p class="govuk-body">2 May 2023</p>
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Feedback provided</h2>
+    <p class="govuk-body">We are in a good place to start the MoU but will need to set up a meeting to discuss the finer details.</p>
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Notes</h2>
+    <p class="govuk-body">I spoke to George Heatherfield from legal who confirmed the correct legal gateway.</p>
+
+
+    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
+    <p class="govuk-body">The Department for Education have been told that this request was accepted.</p>
+    <p class="govuk-body">Contact <a href="#1">data-management@dfe.gov.uk</a> to set up the data share arrangement.</p>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Requested by</h2>
+    <p class="govuk-body">Department for Education</p>
+
+    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Dataset</h2>
+    <p class="govuk-body">Inline-core_reporting-and-location</p>
+
+    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Request received</h2>
+    <p class="govuk-body">18 April 2023</p>
+
+    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Date needed by</h2>
+    <p class="govuk-body">2 November 2023</p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-button-group govuk-!-static-margin-top-9">
+            {{ govukButton({
+                text: "View full request",
+                classes: "govuk-button--secondary",
+                name: "fullRequest",
+                value: "continue"
+            }) }}
+             <a href="received-requests" class="govuk-link">Return to received requests</a>
+        </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Add the UI for request-accepted page.
In the received-requests page there's a ID with link for the completed request

The data is hard coded
![Screenshot 2023-09-04 at 12 01 59](https://github.com/co-cddo/data-marketplace/assets/49984490/7066c589-b88a-474d-892f-8f25e2b2ec78)
