### PR TITLE
Implemented empty text state - Created requests

### DIFF
--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -52,11 +52,10 @@ router.get("/created-requests", async (req: Request, res: Response) => {
     completed: [[{ text: "You have not completed any data share requests.", colspan: 5 }]]
   };
   
-  if (Object.keys(acquirerForms).length === 0) {
+  if (Object.values(acquirerForms).length === 0) {
     allTableRows.pending.push([{ text: "There are no pending data share requests.", colspan: 5}]);
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for (const [_, formData] of Object.entries(acquirerForms)) {
+    for (const [, formData] of Object.entries(acquirerForms)) {
       let formattedDate = "Unrequested";
       const dateValue = formData.steps.date.value as DateStep;
   

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -1,6 +1,13 @@
 import express, { Request, Response } from "express";
-import { DateStep } from "../types/express";
+import { DateStep, ManageShareTableRow } from "../types/express";
 const router = express.Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  const backLink = req.headers.referer || "/";
+  res.render("../views/supplier/manage-shares.njk", {
+    backLink,
+  });
+});
 
 // Function to get the tag class based on the status value
 function getStatusClass(status: string): string {
@@ -15,13 +22,6 @@ function getStatusClass(status: string): string {
       return "govuk-tag--grey";
   }
 }
-
-router.get("/", async (req: Request, res: Response) => {
-  const backLink = req.headers.referer || "/";
-  res.render("../views/supplier/manage-shares.njk", {
-    backLink,
-  });
-});
 
 router.get("/created-requests", async (req: Request, res: Response) => {
   const acquirerForms = req.session.acquirerForms || {};
@@ -41,39 +41,48 @@ router.get("/created-requests", async (req: Request, res: Response) => {
     "Nov",
     "Dec",
   ];
-  const tableRows = [];
+    
+  const allTableRows: {
+    pending: ManageShareTableRow[][],
+    submitted: ManageShareTableRow[][],
+    completed: ManageShareTableRow[][]
+  } = {
+    pending: [],
+    submitted: [[{ text: "There are no submitted data share requests.", colspan: 5 }]],
+    completed: [[{ text: "You have not completed any data share requests.", colspan: 5 }]]
+  };
+  
+  if (Object.keys(acquirerForms).length === 0) {
+    allTableRows.pending.push([{ text: "There are no pending data share requests.", colspan: 5}]);
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const [_, formData] of Object.entries(acquirerForms)) {
+      let formattedDate = "Unrequested";
+      const dateValue = formData.steps.date.value as DateStep;
+  
+      if (dateValue.day && dateValue.month && dateValue.year) {
+        const monthIndex = dateValue.month - 1;
+        const monthName = monthNames[monthIndex];
+        formattedDate = `${dateValue.day} ${monthName} ${dateValue.year}`;
+      }
 
-  for (const [key, formData] of Object.entries(acquirerForms)) {
-    key === formData.requestId;
-    let formattedDate = "Unrequested";
-    const dateValue = formData.steps.date.value as DateStep;
-
-    if (dateValue.day && dateValue.month && dateValue.year) {
-      const monthIndex = dateValue.month - 1;
-      const monthName = monthNames[monthIndex];
-      formattedDate = `${dateValue.day} ${monthName} ${dateValue.year}`;
-    }
-    const row = [
-      {
-        html: `<a href="/acquirer/${formData.dataAsset}/start">${formData.requestId}</a>`,
-      },
-      { text: formData.assetTitle },
-      { text: formData.ownedBy },
-      { text: formattedDate },
-      {
-        html: `<span class="govuk-tag ${getStatusClass(formData.status)}">${
-          formData.status
-        }</span>`,
-      },
+      const row: ManageShareTableRow[] = [
+        { html: `<a href="/acquirer/${formData.dataAsset}/start">${formData.requestId}</a>` },
+        { text: formData.assetTitle },
+        { text: formData.ownedBy },
+        { text: formattedDate },
+        { html: `<span class="govuk-tag ${getStatusClass(formData.status)}">${formData.status}</span>` },
     ];
-    tableRows.push(row);
+  
+    allTableRows.pending.push(row);
+    }
   }
 
   res.render("../views/supplier/created-requests.njk", {
     backLink,
     acquirerForms,
     getStatusClass,
-    tableRows,
+    allTableRows: allTableRows
   });
 });
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -205,3 +205,9 @@ declare module "express-session" {
     backLink: string;
   }
 }
+
+/**
+* Supplier Journey Types & Interfaces start
+*/
+
+export type ManageShareTableRow = { html?: string, text?: string; colspan?: number; classes?: string; } 

--- a/src/views/supplier/created-requests.njk
+++ b/src/views/supplier/created-requests.njk
@@ -44,7 +44,7 @@
                     text: "Status"
                 }
             ],
-            rows: tableRows
+            rows: allTableRows.pending
         }) }}
     </div>
 </div>
@@ -72,7 +72,7 @@
                     text: "Status"
                 }
             ],
-            rows: []
+            rows: allTableRows.submitted
         }) }}
     </div>
 </div>
@@ -100,7 +100,7 @@
                     text: "Decision"
                 }
             ],
-            rows: []
+            rows: allTableRows.completed
         }) }}
     </div>
 </div>


### PR DESCRIPTION
Implemented the empty state text for the created requests page:

![image](https://github.com/co-cddo/data-marketplace/assets/71328022/763f42fd-a807-43c3-8f02-9cc786d80d5c)


## Important
This PR only has the created request empty state text, currently the received requests have hardcoded values and no functionality yet to retrieve data.
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/95f64133-7996-48f4-8475-85d05c5423aa)

When there is some functionality for the received side we have something to work with.