### PR TITLE
DMBM 143 - View user profile

### DIFF
--- a/src/stylesheets/_navigation.scss
+++ b/src/stylesheets/_navigation.scss
@@ -44,11 +44,21 @@ a:hover,
       text-underline-offset: 0.2em;
     }
   }
+
   &.app-navigation__list-item--right {
     float: right;
     padding-right: 0;
-    margin-right: 15px;
+
+    &.not-authenticated {
+      margin-right: -15px;
+    }
+
+    &.authenticated {
+      margin-left: 15px; /* Add spacing to the left when authenticated */
+      margin-right: -15px;
+    }
   }
+
   @include govuk-media-query($from: tablet) {
     @include govuk-font(19, $weight: bold, $line-height: $navigation-height);
     box-sizing: border-box;

--- a/src/stylesheets/_navigation.scss
+++ b/src/stylesheets/_navigation.scss
@@ -47,7 +47,7 @@ a:hover,
   &.app-navigation__list-item--right {
     float: right;
     padding-right: 0;
-    margin-right: -15px;
+    margin-right: 15px;
   }
   @include govuk-media-query($from: tablet) {
     @include govuk-font(19, $weight: bold, $line-height: $navigation-height);

--- a/src/views/partials/navigation.njk
+++ b/src/views/partials/navigation.njk
@@ -14,6 +14,11 @@
                 {% if isAuthenticated %}Sign out{%else%}Sign in{%endif%}
             </a>
           </li>
+          <li class="app-navigation__list-item app-navigation__list-item--right">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={%if isAuthenticated %}"/profile"{%else%}"/#"{%endif%}>
+                Account
+            </a>
+          </li>
       </ul>
     </nav>
 {% endblock %}

--- a/src/views/partials/navigation.njk
+++ b/src/views/partials/navigation.njk
@@ -9,16 +9,18 @@
               Home
             </a>
           </li>
-          <li class="app-navigation__list-item app-navigation__list-item--right">
-            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={%if isAuthenticated %}"/logout"{%else%}"/login"{%endif%}>
-                {% if isAuthenticated %}Sign out{%else%}Sign in{%endif%}
+          <li class="app-navigation__list-item app-navigation__list-item--right {% if isAuthenticated %}authenticated{% else %}not-authenticated{% endif %}">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={% if isAuthenticated %}"/logout"{% else %}"/login"{% endif %}>
+                {% if isAuthenticated %}Sign out{% else %}Sign in{% endif %}
             </a>
           </li>
-          <li class="app-navigation__list-item app-navigation__list-item--right">
-            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={%if isAuthenticated %}"/profile"{%else%}"/login"{%endif%}>
+          {% if isAuthenticated %}
+          <li class="app-navigation__list-item app-navigation__list-item--right authenticated">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href="/profile">
                 Account
             </a>
           </li>
+          {% endif %}
       </ul>
     </nav>
 {% endblock %}

--- a/src/views/partials/navigation.njk
+++ b/src/views/partials/navigation.njk
@@ -15,7 +15,7 @@
             </a>
           </li>
           <li class="app-navigation__list-item app-navigation__list-item--right">
-            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={%if isAuthenticated %}"/profile"{%else%}"/#"{%endif%}>
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link js-app-navigation__link" href={%if isAuthenticated %}"/profile"{%else%}"/login"{%endif%}>
                 Account
             </a>
           </li>

--- a/src/views/profile.njk
+++ b/src/views/profile.njk
@@ -1,19 +1,56 @@
 {% extends "page.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% block content %}
-    <h1>{{ heading }}</h1>
-    {% if user %}
-    Authenticated: {{ isAuthenticated }}<br/>
-    Display name: {{user.display_name}}<br/>
-    Email: {{user.email}}
-        <br/>
-    Share requests:
-    <ul>
-            {% for assetId, requestData in requestForms %}
-                <li>
-                    <a href="/acquirer/{{assetId}}/start">{{assetId}}</a>
-                </li>
-            {% endfor %}
-        </ul>
-        {%endif%}
-    {% endblock %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">Account</h1>
+
+      {% if user %}
+      {{ govukTable({
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: false,
+        rows: [
+          [
+            {
+              text: "Name"
+            },
+            {
+              text: user.display_name
+            }
+          ],
+          [
+            {
+              text: "Email"
+            },
+            {
+              text: user.email
+            }
+          ],
+          [
+            {
+              text: "Organisation"
+            },
+            {
+              text: "Organisation"
+            }
+          ],
+          [
+            {
+              text: "Role"
+            },
+            {
+              text: "Role"
+            }
+          ]
+        ]
+      }) }}
+
+    {% endif %}
+    </div>
+  </div>
+
+{% endblock %}
+

--- a/src/views/profile.njk
+++ b/src/views/profile.njk
@@ -34,7 +34,7 @@
               text: "Organisation"
             },
             {
-              text: "Organisation"
+              text: user.organisation if user.organisation else "unavailable"
             }
           ],
           [
@@ -42,7 +42,7 @@
               text: "Role"
             },
             {
-              text: "Role"
+              text: user.role if user.role else "unavailable"
             }
           ]
         ]
@@ -53,4 +53,3 @@
   </div>
 
 {% endblock %}
-


### PR DESCRIPTION
This PR implements the profile page to display relevant user information. The profile page is accessed by a navigation link 'Account', and is only displayed on the nav bar if a user is signed in. The information on the page is only available if there is a user object.
We currently do not store organisation and role on the user object but this is a work in progress. If these are available (via user.organisation or user.role), then they are displayed, otherwise 'unavailable' is shown. 