### PR TITLE
Received requests setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*
 /public/stycssles/
 .env
 .DS_Store
+requests.http

--- a/requests/requests.http.template
+++ b/requests/requests.http.template
@@ -1,0 +1,29 @@
+@API = http://localhost:8000
+@ops-api-key = <copy from API .env>
+@jwt = Bearer <copy from browser>
+@user = <first.last>@digital.cabinet-office.gov.uk
+
+
+### List all users (ops only):
+GET {{API}}/users
+x-api-key: {{ops-api-key}}
+
+### Set user organisation (ops only):
+PUT {{API}}/users/{{user}}/org
+x-api-key: {{ops-api-key}}
+
+{
+    "org": "department-for-work-pensions"
+}
+
+### Get user (JWT):
+GET {{API}}/users/me
+Authorization: {{jwt}}
+
+### GET Share requests received by org (JWT):
+GET {{API}}/manage-shares/received-requests
+Authorization: {{jwt}}
+
+### GET Share request by ID (JWT)
+GET {{API}}/manage-shares/received-requests/eb9267c8-5f5d-468a-bc46-b5201d56b991
+Authorization: {{jwt}}

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -343,9 +343,8 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
 
   if (formdata.stepHistory && formdata.stepHistory.length > 0) {
     // Otherwise, set it to the previous step from stepHistory
-    backLink = `/acquirer/${resourceID}/${
-      formdata.stepHistory[formdata.stepHistory.length - 1]
-    }?action=back`;
+    backLink = `/acquirer/${resourceID}/${formdata.stepHistory[formdata.stepHistory.length - 1]
+      }?action=back`;
   } else {
     backLink = `/acquirer/${resourceID}/start`;
   }
@@ -488,7 +487,7 @@ router.post("/:resourceID/:step", async (req: Request, res: Response) => {
   // Send the formdata to the backend if logged in
   if (req.isAuthenticated()) {
     try {
-      await axios.put(URL, { jwt: req.cookies.jwtToken, sharedata: formdata });
+      await axios.put(URL, { sharedata: formdata }, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
     } catch (error: unknown) {
       console.error("Error sending formdata to backend");
       if (axios.isAxiosError(error)) {

--- a/src/routes/profileRoutes.ts
+++ b/src/routes/profileRoutes.ts
@@ -3,7 +3,7 @@ const router = express.Router();
 import { authenticateJWT } from "../middleware/authMiddleware";
 import axios from "axios";
 
-const URL = `${process.env.API_ENDPOINT}/user`;
+const URL = `${process.env.API_ENDPOINT}/login`;
 
 router.get(
   "/",
@@ -15,7 +15,7 @@ router.get(
 
     let requestForms = {};
     try {
-      const response = await axios.put(URL, { token: req.cookies.jwtToken });
+      const response = await axios.get(URL, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
       requestForms = response.data["sharedata"] || {};
       req.session.acquirerForms = requestForms;
     } catch (error) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -154,7 +154,9 @@ type FormStatus =
   | "IN PROGRESS"
   | "AWAITING REVIEW"
   | "RETURNED"
-  | "IN REVIEW";
+  | "IN REVIEW"
+  | "ACCEPTED"
+  | "REJECTED"
 
 export type StepValue =
   | string


### PR DESCRIPTION
# Received requests setup
This PR is the partner of [this PR in the API repo](https://github.com/co-cddo/data-marketplace-api/pull/12). See that other PR for details

# Changes
- Updated the `/user` url to `/login` to match the change in the API.
- Updated the calls to the share request data and login API endpoints to send the JWT as a Bearer token in an `Authorization` header instead of the request body.
- Added a `requests.http.template` file which can be renamed to `requests.http` and used with the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) VSCode extension to test some of the new API endpoints. The `ops-api-key`, `jwt` and `user` variables need to be set to real values.
- Added `ACCEPTED` and `REJECTED` to the allowed share request form statuses.