### PR TITLE
Patch/additional validation acquirer steps

### DIFF
--- a/src/middleware/validateFormMiddleware.ts
+++ b/src/middleware/validateFormMiddleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction } from "connect";
 import { Request, Response } from "express-serve-static-core";
-import { CustomValidator, body} from "express-validator";
+import { CustomValidator, body } from "express-validator";
 
 const dateValidator: CustomValidator = (value, { req }) => {
   const day = req.body.day;
@@ -39,7 +39,6 @@ const dateValidator: CustomValidator = (value, { req }) => {
   return true;
 };
 
-
 function getDateValidation() {
   return [
     body("day")
@@ -67,48 +66,26 @@ function getDateValidation() {
 }
 
 function getDataAccessValidation() {
-  return [
-    body("data-access")
-      .exists()
-      .withMessage("Please select an option.")
-  ];
+  return [body("data-access").exists().withMessage("Please select an option.")];
 }
 
 function getDataTravelValidation() {
-  return [
-    body("data-travel")
-      .exists()
-      .withMessage("Please select an option.")
-  ];
+  return [body("data-travel").exists().withMessage("Please select an option.")];
 }
 
 function getRoleValidation() {
-  return [
-    body("role")
-      .exists()
-      .withMessage("Please select an option.")
-  ];
+  return [body("role").exists().withMessage("Please select an option.")];
 }
 function getFormatValidation() {
-  return [
-    body("format")
-      .exists()
-      .withMessage("Please select an option.")
-  ];
+  return [body("format").exists().withMessage("Please select an option.")];
 }
 function getDeliveryValidation() {
-  return [
-    body("delivery")
-      .exists()
-      .withMessage("Please select an option.")
-  ];
+  return [body("delivery").exists().withMessage("Please select an option.")];
 }
 
 function getSecurityReviewValidation() {
   return [
-    body("security-review")
-      .exists()
-      .withMessage("Please select an option.")
+    body("security-review").exists().withMessage("Please select an option."),
   ];
 }
 
@@ -133,7 +110,11 @@ function getValidationRules(step: string) {
   }
 }
 
-export const validateFormMiddleware = (req: Request, res: Response, next: NextFunction) => {
+export const validateFormMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
   const formStep = req.params.step;
   const validationRules = getValidationRules(formStep);
 
@@ -156,4 +137,3 @@ export const validateFormMiddleware = (req: Request, res: Response, next: NextFu
     next();
   }
 };
-

--- a/src/middleware/validateFormMiddleware.ts
+++ b/src/middleware/validateFormMiddleware.ts
@@ -1,4 +1,6 @@
-import { CustomValidator, body } from "express-validator";
+import { NextFunction } from "connect";
+import { Request, Response } from "express-serve-static-core";
+import { CustomValidator, body} from "express-validator";
 
 const dateValidator: CustomValidator = (value, { req }) => {
   const day = req.body.day;
@@ -37,26 +39,121 @@ const dateValidator: CustomValidator = (value, { req }) => {
   return true;
 };
 
-export const validateFormMiddleware = [
-  body("day")
-    .optional({ checkFalsy: true })
-    .isInt({ min: 1, max: 31 })
-    .withMessage("Day is invalid")
-    .custom(dateValidator)
-    .escape(),
-  body("month")
-    .optional({ checkFalsy: true })
-    .isInt({ min: 1, max: 12 })
-    .withMessage("Month is invalid")
-    .custom(dateValidator)
-    .escape(),
-  body("year")
-    .optional({ checkFalsy: true })
-    .isInt({
-      min: new Date().getFullYear() - 200,
-      max: new Date().getFullYear() + 10,
-    })
-    .withMessage("Year is invalid")
-    .custom(dateValidator)
-    .escape(),
-];
+
+function getDateValidation() {
+  return [
+    body("day")
+      .optional({ checkFalsy: true })
+      .isInt({ min: 1, max: 31 })
+      .withMessage("Day is invalid")
+      .custom(dateValidator)
+      .escape(),
+    body("month")
+      .optional({ checkFalsy: true })
+      .isInt({ min: 1, max: 12 })
+      .withMessage("Month is invalid")
+      .custom(dateValidator)
+      .escape(),
+    body("year")
+      .optional({ checkFalsy: true })
+      .isInt({
+        min: new Date().getFullYear() - 200,
+        max: new Date().getFullYear() + 10,
+      })
+      .withMessage("Year is invalid")
+      .custom(dateValidator)
+      .escape(),
+  ];
+}
+
+function getDataAccessValidation() {
+  return [
+    body("data-access")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+
+function getDataTravelValidation() {
+  return [
+    body("data-travel")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+
+function getRoleValidation() {
+  return [
+    body("role")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+function getFormatValidation() {
+  return [
+    body("format")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+function getDeliveryValidation() {
+  return [
+    body("delivery")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+
+function getSecurityReviewValidation() {
+  return [
+    body("security-review")
+      .exists()
+      .withMessage("Please select an option.")
+  ];
+}
+
+function getValidationRules(step: string) {
+  switch (step) {
+    case "date":
+      return getDateValidation();
+    case "data-access":
+      return getDataAccessValidation();
+    case "data-travel":
+      return getDataTravelValidation();
+    case "role":
+      return getRoleValidation();
+    case "delivery":
+      return getDeliveryValidation();
+    case "format":
+      return getFormatValidation();
+    case "security-review":
+      return getSecurityReviewValidation();
+    default:
+      return [];
+  }
+}
+
+export const validateFormMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const formStep = req.params.step;
+  const validationRules = getValidationRules(formStep);
+
+  if (validationRules.length > 0) {
+    const runValidation = (index: number) => {
+      if (index >= validationRules.length) {
+        next();
+        return;
+      }
+      validationRules[index](req, res, (err) => {
+        if (err) {
+          next(err);
+        } else {
+          runValidation(index + 1);
+        }
+      });
+    };
+    runValidation(0);
+  } else {
+    next();
+  }
+};
+

--- a/src/middleware/validateFormMiddleware.ts
+++ b/src/middleware/validateFormMiddleware.ts
@@ -116,6 +116,11 @@ export const validateFormMiddleware = (
   next: NextFunction,
 ) => {
   const formStep = req.params.step;
+
+  if (req.body.returnButton) {
+    return next();
+  }
+
   const validationRules = getValidationRules(formStep);
 
   if (validationRules.length > 0) {

--- a/src/views/acquirer/data-access.njk
+++ b/src/views/acquirer/data-access.njk
@@ -2,6 +2,10 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -30,7 +34,8 @@
                       text: "Yes, we are collaborating with other organisations",
                       checked: savedValue === 'yes'
                       }
-                  ]
+                  ],
+                  errorMessage: errorText if errorText else undefined
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/data-access.njk
+++ b/src/views/acquirer/data-access.njk
@@ -2,10 +2,6 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -35,7 +31,7 @@
                       checked: savedValue === 'yes'
                       }
                   ],
-                  errorMessage: errorText if errorText else undefined
+                  errorMessage: errorText
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/data-travel.njk
+++ b/src/views/acquirer/data-travel.njk
@@ -2,10 +2,6 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -35,7 +31,7 @@
                       checked: savedValue === 'yes'
                       }
                   ],
-                  errorMessage: errorText if errorText else undefined
+                  errorMessage: errorText
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/data-travel.njk
+++ b/src/views/acquirer/data-travel.njk
@@ -2,6 +2,10 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -30,7 +34,8 @@
                       text: "Yes, it will leave the UK",
                       checked: savedValue === 'yes'
                       }
-                  ]
+                  ],
+                  errorMessage: errorText if errorText else undefined
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/date.njk
+++ b/src/views/acquirer/date.njk
@@ -2,11 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
-{% set errorText = ({text: errorMessage}
-if errorMessage else 
-  false
-) %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/views/acquirer/delivery.njk
+++ b/src/views/acquirer/delivery.njk
@@ -3,6 +3,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -44,7 +48,8 @@
                 html: somethingHTML
               }
             }
-          ]
+          ],
+          errorMessage: errorText if errorText else undefined
           }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/src/views/acquirer/delivery.njk
+++ b/src/views/acquirer/delivery.njk
@@ -3,10 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -49,7 +45,7 @@
               }
             }
           ],
-          errorMessage: errorText if errorText else undefined
+          errorMessage: errorText
           }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/src/views/acquirer/format.njk
+++ b/src/views/acquirer/format.njk
@@ -3,10 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -49,7 +45,7 @@
             }
           }
         ],
-        errorMessage: errorText if errorText else undefined
+        errorMessage: errorText
         }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/src/views/acquirer/format.njk
+++ b/src/views/acquirer/format.njk
@@ -3,6 +3,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -44,7 +48,8 @@
                 html: somethingHTML
             }
           }
-        ]
+        ],
+        errorMessage: errorText if errorText else undefined
         }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/src/views/acquirer/lawful-basis-special.njk
+++ b/src/views/acquirer/lawful-basis-special.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
- 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/views/acquirer/role.njk
+++ b/src/views/acquirer/role.njk
@@ -2,10 +2,6 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -54,7 +50,7 @@
                       checked: savedValue === "don't know"
                       }
                   ],
-                  errorMessage: errorText if errorText else undefined
+                  errorMessage: errorText
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/role.njk
+++ b/src/views/acquirer/role.njk
@@ -2,6 +2,10 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -33,7 +37,7 @@
                           text: "We want to share responsibility with another department"
                       }
                       },
-                       {
+                      {
                       value: "processor",
                       text: "Processor",
                       checked: savedValue === 'processor',
@@ -49,7 +53,8 @@
                       text: "I don't know",
                       checked: savedValue === "don't know"
                       }
-                  ]
+                  ],
+                  errorMessage: errorText if errorText else undefined
                   }) }}
           <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/security-review.njk
+++ b/src/views/acquirer/security-review.njk
@@ -2,10 +2,6 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% if errorMessage %}
-    {% set errorText = {text: errorMessage} %}
-{% endif %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -35,7 +31,7 @@
                 checked: savedValue === 'no'
                 }
             ],
-            errorMessage: errorText if errorText else undefined
+            errorMessage: errorText
             }) }}
             <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/acquirer/security-review.njk
+++ b/src/views/acquirer/security-review.njk
@@ -2,6 +2,10 @@
 {%- from "govuk/components/radios/macro.njk" import govukRadios -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% endif %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -30,7 +34,8 @@
                 text: "No",
                 checked: savedValue === 'no'
                 }
-            ]
+            ],
+            errorMessage: errorText if errorText else undefined
             }) }}
             <div class="govuk-button-group">
             {{ govukButton({

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -1,6 +1,13 @@
 {% extends "govuk/template.njk" %}
 
+
 {% block pageTitle %}Data Marketplace{% endblock %}
+
+{% if errorMessage %}
+    {% set errorText = {text: errorMessage} %}
+{% else %}
+    {% set errorText = undefined %}
+{% endif %}
 
 {% block head %}
     <link href="/govuk-frontend/all.css" rel="text/stylesheet">


### PR DESCRIPTION
Implemented additional use cases for the newly implemented validation change with express-validator.

Added additional cases to most radio pages/steps excluding legal-power and legal-review 

A list of effected pages/steps that need to have a `radio selected`:

data-access,
data-travel,
role,
delivery,
format,
security-review,

we now see an error as such:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/3a40cc7f-5e08-491a-9870-d7274fae02a2)

for each of the pages/steps mentioned