### PR TITLE
Replace internals with apis

### DIFF
--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -1,255 +1,249 @@
-import axios from "axios";
-import { fetchResources, fetchResourceById } from "../src/services/findService";
-import mockData from "./mock/mockData.json";
-import singleMockData from "./mock/singleMockData.json";
+// import axios from "axios";
+// import { fetchResources, fetchResourceById } from "../src/services/findService";
+// import mockData from "./mock/mockData.json";
+// import singleMockData from "./mock/singleMockData.json";
 
-// Add dotenv config to test suite
-import dotenv from 'dotenv';
-dotenv.config();
+// // Add dotenv config to test suite
+// import dotenv from 'dotenv';
+// dotenv.config();
 
-// Mock axios get function
-jest.mock("axios");
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+// // Mock axios get function
+// jest.mock("axios");
+// const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+// describe("fetchResources", () => {
+//   beforeEach(() => {
+//     // Set up the axios get mock before each test
+//     process.env.API_ENDPOINT = "http://mock-test.endpoint.com/test-api";
+//     mockedAxios.get.mockResolvedValue({ data: mockData });
+//   });
 
-describe("fetchResources", () => {
-  beforeEach(() => {
-    // Set up the axios get mock before each test
-    process.env.API_ENDPOINT = "http://mock-test.endpoint.com/test-api";
-    mockedAxios.get.mockResolvedValue({ data: mockData });
-  });
+//   afterEach(() => {
+//     // Clear the mock after each test
+//     mockedAxios.get.mockClear();
+//     delete process.env.API_ENDPOINT;
+//   });
 
-  afterEach(() => {
-    // Clear the mock after each test
-    mockedAxios.get.mockClear();
-    delete process.env.API_ENDPOINT;
-  });
+//   it("should return the correct data when no query is provided", async () => {
+//     const expectedData = mockData.data;
+//     const result = await fetchResources();
 
-  it("should return the correct data when no query is provided", async () => {
-    const expectedData = mockData.data;
-    const result = await fetchResources();
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//   it("should return filtered data when a query is provided", async () => {
+//     const query = "test";
+//     const expectedData = mockData.data.filter((resource) => {
+//       return Object.values(resource).some(
+//         (value) => value?.toString().toLowerCase().includes(query),
+//       );
+//     });
+//     const result = await fetchResources(query);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   })
 
-  it("should return filtered data when a query is provided", async () => {
-    const query = "test";
-    const expectedData = mockData.data.filter((resource) => {
-      return Object.values(resource).some(
-        (value) => value?.toString().toLowerCase().includes(query),
-      );
-    });
-    const result = await fetchResources(query);
-    expect(result.resources).toEqual(expectedData); 
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  })
+//   it("should return filtered data when one organisation filter is provided", async () => {
+//     // the filter gets passed as a string when there is only one filter selected
+//     const organisationFilter = "department-for-test";
 
-  it("should return filtered data when one organisation filter is provided", async () => {
-    // the filter gets passed as a string when there is only one filter selected
-    const organisationFilter = "department-for-test";
-    
-    const expectedData = mockData.data.filter((resource) => {
-      return resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
-    });
-    // use undefined in the function call to explicitly state that we"re not passing a value for query
-    const result = await fetchResources(undefined, [organisationFilter]);
-    expect(result.resources).toEqual(expectedData); 
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
-  
+//     const expectedData = mockData.data.filter((resource) => {
+//       return resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
+//     });
+//     // use undefined in the function call to explicitly state that we"re not passing a value for query
+//     const result = await fetchResources(undefined, [organisationFilter]);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-  it("should return filtered data when two organisation filters are provided", async () => {
-    // the filter gets passed as an array when there is more than one filter selected
-    const organisationFilters = ["department-for-test", "department-for-test-test"];
-  
-    const expectedData = mockData.data.filter(resource => {
-      return organisationFilters.includes(resource.organisation.slug.toLowerCase());
-    });
-    // use undefined in the function call to explicitly state that we"re not passing a value for query
-    const result = await fetchResources(undefined, organisationFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//   it("should return filtered data when two organisation filters are provided", async () => {
+//     // the filter gets passed as an array when there is more than one filter selected
+//     const organisationFilters = ["department-for-test", "department-for-test-test"];
 
-  it("should return filtered data when both a query and an organisation filter are provided", async () => {
-    const query = "test service";
-    const organisationFilter = "department-for-test";
+//     const expectedData = mockData.data.filter(resource => {
+//       return organisationFilters.includes(resource.organisation.slug.toLowerCase());
+//     });
+//     // use undefined in the function call to explicitly state that we"re not passing a value for query
+//     const result = await fetchResources(undefined, organisationFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-    const expectedData = mockData.data.filter((resource) => {
-        const matchesQuery = Object.values(resource).some(
-            (value) => value?.toString().toLowerCase().includes(query)
-        );
-        const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
-        
-        return matchesQuery && matchesOrgFilter;
-    });
+//   it("should return filtered data when both a query and an organisation filter are provided", async () => {
+//     const query = "test service";
+//     const organisationFilter = "department-for-test";
 
-    const result = await fetchResources(query, [organisationFilter]);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//     const expectedData = mockData.data.filter((resource) => {
+//         const matchesQuery = Object.values(resource).some(
+//             (value) => value?.toString().toLowerCase().includes(query)
+//         );
+//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
 
-  it("should return no data when neither the query nor the organisation filter matches", async () => {
-    const query = "nonexistentquery";
-    const organisationFilter = "nonexistent-organisation";
-    const expectedData = mockData.data.filter((resource) => {
-        const matchesQuery = Object.values(resource).some(
-            (value) => value?.toString().toLowerCase().includes(query)
-        );
-        const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
+//         return matchesQuery && matchesOrgFilter;
+//     });
 
-        return matchesQuery || matchesOrgFilter;
-    });
-    expect(expectedData.length).toBe(0);
+//     const result = await fetchResources(query, [organisationFilter]);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-    const result = await fetchResources(query, [organisationFilter]);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//   it("should return no data when neither the query nor the organisation filter matches", async () => {
+//     const query = "nonexistentquery";
+//     const organisationFilter = "nonexistent-organisation";
+//     const expectedData = mockData.data.filter((resource) => {
+//         const matchesQuery = Object.values(resource).some(
+//             (value) => value?.toString().toLowerCase().includes(query)
+//         );
+//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
 
+//         return matchesQuery || matchesOrgFilter;
+//     });
+//     expect(expectedData.length).toBe(0);
 
-  it("should return filtered data when one theme filter is provided", async () => {
-    const themeFilter = "Transport";
-      
-    const expectedData = mockData.data.filter((resource) => {
-      return resource.theme.includes(themeFilter);
-    });
-    
-    const result = await fetchResources(undefined, undefined, [themeFilter]);
-    expect(result.resources).toEqual(expectedData); 
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//     const result = await fetchResources(query, [organisationFilter]);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-  it("should return filtered data when two theme filters are provided", async () => {
-    const themeFilters = ["Transport", "Mapping"];
+//   it("should return filtered data when one theme filter is provided", async () => {
+//     const themeFilter = "Transport";
 
-    const expectedData = mockData.data.filter(resource => {
-      return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
-    });
-    
-    const result = await fetchResources(undefined, undefined, themeFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//     const expectedData = mockData.data.filter((resource) => {
+//       return resource.theme.includes(themeFilter);
+//     });
 
+//     const result = await fetchResources(undefined, undefined, [themeFilter]);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-  it("should return filtered data when both a query and a theme filter are provided", async () => {
-    const query = "test service";
-    const themeFilters = ["Transport"];
-  
-    const expectedData = mockData.data.filter((resource) => {
-      const matchesQuery = Object.values(resource).some(
-        (value) => value?.toString().toLowerCase().includes(query)
-      );
-  
-      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
-  
-      return matchesQuery && matchesThemeFilter;
-    });
-  
-    const result = await fetchResources(query, undefined, themeFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
-  
+//   it("should return filtered data when two theme filters are provided", async () => {
+//     const themeFilters = ["Transport", "Mapping"];
 
-  it("should return no data when neither the query nor the theme filter matches", async () => {
-    const query = "nonexistentquery";
-    const themeFilters = ["nonexistent-organisation"];
-    const expectedData = mockData.data.filter((resource) => {
-        const matchesQuery = Object.values(resource).some(
-            (value) => value?.toString().toLowerCase().includes(query)
-        );
-        const matchesThemeFilter = resource.theme === themeFilters;
+//     const expectedData = mockData.data.filter(resource => {
+//       return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
+//     });
 
-        return matchesQuery || matchesThemeFilter;
-    });
-    expect(expectedData.length).toBe(0);
+//     const result = await fetchResources(undefined, undefined, themeFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-    const result = await fetchResources(query, undefined, themeFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//   it("should return filtered data when both a query and a theme filter are provided", async () => {
+//     const query = "test service";
+//     const themeFilters = ["Transport"];
 
-  it("should return filtered data when both query, organisation filters, and theme filters are provided", async () => {
-    const query = "test service";
-    const organisationFilters = ["department-for-test"];
-    const themeFilters = ["Transport"];
-  
-    const expectedData = mockData.data.filter((resource) => {
-      const matchesQuery = Object.values(resource).some(
-        (value) => value?.toString().toLowerCase().includes(query)
-      );
-  
-      const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
-      const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
-  
-      return matchesQuery && matchesOrgFilter && matchesThemeFilter;
-    });
-  
-    const result = await fetchResources(query, organisationFilters, themeFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//     const expectedData = mockData.data.filter((resource) => {
+//       const matchesQuery = Object.values(resource).some(
+//         (value) => value?.toString().toLowerCase().includes(query)
+//       );
 
-  it("should return no data when neither the query nor the organisation filter nor the theme filter matches", async () => {
-    const query = "nonexistentquery";
-    const organisationFilters = "non-existent-theme";
-    const themeFilters = ["nonexistent-organisation"];
-    const expectedData = mockData.data.filter((resource) => {
-        const matchesQuery = Object.values(resource).some(
-            (value) => value?.toString().toLowerCase().includes(query)
-        );
-        const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilters.toLowerCase();
-        const matchesThemeFilter = resource.theme === themeFilters;
+//       const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
 
-        return matchesQuery || matchesThemeFilter || matchesOrgFilter;
-    });
-    expect(expectedData.length).toBe(0);
+//       return matchesQuery && matchesThemeFilter;
+//     });
 
-    const result = await fetchResources(query, undefined, themeFilters);
-    expect(result.resources).toEqual(expectedData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-  });
+//     const result = await fetchResources(query, undefined, themeFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-  it("should throw an error when the axios request fails", async () => {
-    mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
-    await expect(fetchResources("test")).rejects.toThrow("An error occurred while fetching data from the API");
-  });
-});
+//   it("should return no data when neither the query nor the theme filter matches", async () => {
+//     const query = "nonexistentquery";
+//     const themeFilters = ["nonexistent-organisation"];
+//     const expectedData = mockData.data.filter((resource) => {
+//         const matchesQuery = Object.values(resource).some(
+//             (value) => value?.toString().toLowerCase().includes(query)
+//         );
+//         const matchesThemeFilter = resource.theme === themeFilters;
 
-describe("fetchResourceById", () => {
-  beforeEach(() => {
-    // Set up the axios get mock before each test
-    process.env.API_ENDPOINT = "http://mock-test.endpoint.com/";
-    mockedAxios.get.mockResolvedValue({ data: singleMockData });
-  });
+//         return matchesQuery || matchesThemeFilter;
+//     });
+//     expect(expectedData.length).toBe(0);
 
-  afterEach(() => {
-    // Clear the mock after each test
-    mockedAxios.get.mockClear();
-    delete process.env.API_ENDPOINT;
-  });
+//     const result = await fetchResources(query, undefined, themeFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
 
-  it("should return the correct resource data when valid ID is provided", async () => {
-    const resourceId = singleMockData.asset.identifier; 
-    const expectedResource = singleMockData.asset;
-    const result = await fetchResourceById(resourceId);
+//   it("should return filtered data when both query, organisation filters, and theme filters are provided", async () => {
+//     const query = "test service";
+//     const organisationFilters = ["department-for-test"];
+//     const themeFilters = ["Transport"];
 
-    expect(result).toEqual(expectedResource);
-  });
+//     const expectedData = mockData.data.filter((resource) => {
+//       const matchesQuery = Object.values(resource).some(
+//         (value) => value?.toString().toLowerCase().includes(query)
+//       );
 
-  it("should throw an error when the provided ID does not exist", async () => {
-    const resourceId = "non-existing-id";
-    mockedAxios.get.mockResolvedValue({ data: { asset: null } }); 
-    await expect(fetchResourceById(resourceId)).rejects.toThrow("Resource not found.");
-  });
-  
+//       const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
+//       const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
 
-  it("should throw an error when the axios request fails", async () => {
-    const resourceId = mockData.data[0].identifier;
-    mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
-    await expect(fetchResourceById(resourceId)).rejects.toThrow("An error occurred while fetching data from the API");
-  });
-});
+//       return matchesQuery && matchesOrgFilter && matchesThemeFilter;
+//     });
+
+//     const result = await fetchResources(query, organisationFilters, themeFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
+
+//   it("should return no data when neither the query nor the organisation filter nor the theme filter matches", async () => {
+//     const query = "nonexistentquery";
+//     const organisationFilters = "non-existent-theme";
+//     const themeFilters = ["nonexistent-organisation"];
+//     const expectedData = mockData.data.filter((resource) => {
+//         const matchesQuery = Object.values(resource).some(
+//             (value) => value?.toString().toLowerCase().includes(query)
+//         );
+//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilters.toLowerCase();
+//         const matchesThemeFilter = resource.theme === themeFilters;
+
+//         return matchesQuery || matchesThemeFilter || matchesOrgFilter;
+//     });
+//     expect(expectedData.length).toBe(0);
+
+//     const result = await fetchResources(query, undefined, themeFilters);
+//     expect(result.resources).toEqual(expectedData);
+//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
+//   });
+
+//   it("should throw an error when the axios request fails", async () => {
+//     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
+//     await expect(fetchResources("test")).rejects.toThrow("An error occurred while fetching data from the API");
+//   });
+// });
+
+// describe("fetchResourceById", () => {
+//   beforeEach(() => {
+//     // Set up the axios get mock before each test
+//     process.env.API_ENDPOINT = "http://mock-test.endpoint.com/";
+//     mockedAxios.get.mockResolvedValue({ data: singleMockData });
+//   });
+
+//   afterEach(() => {
+//     // Clear the mock after each test
+//     mockedAxios.get.mockClear();
+//     delete process.env.API_ENDPOINT;
+//   });
+
+//   it("should return the correct resource data when valid ID is provided", async () => {
+//     const resourceId = singleMockData.asset.identifier;
+//     const expectedResource = singleMockData.asset;
+//     const result = await fetchResourceById(resourceId);
+
+//     expect(result).toEqual(expectedResource);
+//   });
+
+//   it("should throw an error when the provided ID does not exist", async () => {
+//     const resourceId = "non-existing-id";
+//     mockedAxios.get.mockResolvedValue({ data: { asset: null } });
+//     await expect(fetchResourceById(resourceId)).rejects.toThrow("Resource not found.");
+//   });
+
+//   it("should throw an error when the axios request fails", async () => {
+//     const resourceId = mockData.data[0].identifier;
+//     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
+//     await expect(fetchResourceById(resourceId)).rejects.toThrow("An error occurred while fetching data from the API");
+//   });
+// });

--- a/__tests__/find.test.ts
+++ b/__tests__/find.test.ts
@@ -1,249 +1,44 @@
-// import axios from "axios";
-// import { fetchResources, fetchResourceById } from "../src/services/findService";
-// import mockData from "./mock/mockData.json";
-// import singleMockData from "./mock/singleMockData.json";
+import request from "supertest";
+import app from "../src/app";
+import {
+  fetchResources,
+  fetchOrganisations,
+} from "../src/services/findService";
+jest.mock("../src/services/findService");
+describe("GET /", () => {
+  it("should render the find.njk template with data when API calls are successful", async () => {
+    const mockResources = [
+      { id: 1, title: "Resource 1", type: "dataservice" },
+      { id: 199, title: "Resource 112", type: "dataservice" },
+    ];
+    const mockOrganisations = [
+      { id: "org1", title: "Org 1" },
+      { id: "org2", title: "Org 2" },
+    ];
 
-// // Add dotenv config to test suite
-// import dotenv from 'dotenv';
-// dotenv.config();
+    (fetchResources as jest.Mock).mockResolvedValue({
+      resources: mockResources,
+    });
+    (fetchOrganisations as jest.Mock).mockResolvedValue(mockOrganisations);
 
-// // Mock axios get function
-// jest.mock("axios");
-// const mockedAxios = axios as jest.Mocked<typeof axios>;
+    const response = await request(app).get("/find");
 
-// describe("fetchResources", () => {
-//   beforeEach(() => {
-//     // Set up the axios get mock before each test
-//     process.env.API_ENDPOINT = "http://mock-test.endpoint.com/test-api";
-//     mockedAxios.get.mockResolvedValue({ data: mockData });
-//   });
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("Resource 1");
+    expect(response.text).toContain("Resource 112");
+    expect(response.text).toContain("Org 1");
+    expect(response.text).toContain("Org 2");
+    expect(response.text).not.toContain("Org 3");
+  });
 
-//   afterEach(() => {
-//     // Clear the mock after each test
-//     mockedAxios.get.mockClear();
-//     delete process.env.API_ENDPOINT;
-//   });
+  it("should render the find.njk template with error message when API calls fail", async () => {
+    (fetchResources as jest.Mock).mockRejectedValue(new Error("API error"));
 
-//   it("should return the correct data when no query is provided", async () => {
-//     const expectedData = mockData.data;
-//     const result = await fetchResources();
+    const response = await request(app).get("/find");
 
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when a query is provided", async () => {
-//     const query = "test";
-//     const expectedData = mockData.data.filter((resource) => {
-//       return Object.values(resource).some(
-//         (value) => value?.toString().toLowerCase().includes(query),
-//       );
-//     });
-//     const result = await fetchResources(query);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   })
-
-//   it("should return filtered data when one organisation filter is provided", async () => {
-//     // the filter gets passed as a string when there is only one filter selected
-//     const organisationFilter = "department-for-test";
-
-//     const expectedData = mockData.data.filter((resource) => {
-//       return resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
-//     });
-//     // use undefined in the function call to explicitly state that we"re not passing a value for query
-//     const result = await fetchResources(undefined, [organisationFilter]);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when two organisation filters are provided", async () => {
-//     // the filter gets passed as an array when there is more than one filter selected
-//     const organisationFilters = ["department-for-test", "department-for-test-test"];
-
-//     const expectedData = mockData.data.filter(resource => {
-//       return organisationFilters.includes(resource.organisation.slug.toLowerCase());
-//     });
-//     // use undefined in the function call to explicitly state that we"re not passing a value for query
-//     const result = await fetchResources(undefined, organisationFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when both a query and an organisation filter are provided", async () => {
-//     const query = "test service";
-//     const organisationFilter = "department-for-test";
-
-//     const expectedData = mockData.data.filter((resource) => {
-//         const matchesQuery = Object.values(resource).some(
-//             (value) => value?.toString().toLowerCase().includes(query)
-//         );
-//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
-
-//         return matchesQuery && matchesOrgFilter;
-//     });
-
-//     const result = await fetchResources(query, [organisationFilter]);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return no data when neither the query nor the organisation filter matches", async () => {
-//     const query = "nonexistentquery";
-//     const organisationFilter = "nonexistent-organisation";
-//     const expectedData = mockData.data.filter((resource) => {
-//         const matchesQuery = Object.values(resource).some(
-//             (value) => value?.toString().toLowerCase().includes(query)
-//         );
-//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilter.toLowerCase();
-
-//         return matchesQuery || matchesOrgFilter;
-//     });
-//     expect(expectedData.length).toBe(0);
-
-//     const result = await fetchResources(query, [organisationFilter]);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when one theme filter is provided", async () => {
-//     const themeFilter = "Transport";
-
-//     const expectedData = mockData.data.filter((resource) => {
-//       return resource.theme.includes(themeFilter);
-//     });
-
-//     const result = await fetchResources(undefined, undefined, [themeFilter]);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when two theme filters are provided", async () => {
-//     const themeFilters = ["Transport", "Mapping"];
-
-//     const expectedData = mockData.data.filter(resource => {
-//       return themeFilters.some(themeFilter => resource.theme.includes(themeFilter));
-//     });
-
-//     const result = await fetchResources(undefined, undefined, themeFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when both a query and a theme filter are provided", async () => {
-//     const query = "test service";
-//     const themeFilters = ["Transport"];
-
-//     const expectedData = mockData.data.filter((resource) => {
-//       const matchesQuery = Object.values(resource).some(
-//         (value) => value?.toString().toLowerCase().includes(query)
-//       );
-
-//       const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
-
-//       return matchesQuery && matchesThemeFilter;
-//     });
-
-//     const result = await fetchResources(query, undefined, themeFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return no data when neither the query nor the theme filter matches", async () => {
-//     const query = "nonexistentquery";
-//     const themeFilters = ["nonexistent-organisation"];
-//     const expectedData = mockData.data.filter((resource) => {
-//         const matchesQuery = Object.values(resource).some(
-//             (value) => value?.toString().toLowerCase().includes(query)
-//         );
-//         const matchesThemeFilter = resource.theme === themeFilters;
-
-//         return matchesQuery || matchesThemeFilter;
-//     });
-//     expect(expectedData.length).toBe(0);
-
-//     const result = await fetchResources(query, undefined, themeFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return filtered data when both query, organisation filters, and theme filters are provided", async () => {
-//     const query = "test service";
-//     const organisationFilters = ["department-for-test"];
-//     const themeFilters = ["Transport"];
-
-//     const expectedData = mockData.data.filter((resource) => {
-//       const matchesQuery = Object.values(resource).some(
-//         (value) => value?.toString().toLowerCase().includes(query)
-//       );
-
-//       const matchesOrgFilter = organisationFilters.includes(resource.organisation.slug.toLowerCase());
-//       const matchesThemeFilter = resource.theme.some(theme => themeFilters.includes(theme));
-
-//       return matchesQuery && matchesOrgFilter && matchesThemeFilter;
-//     });
-
-//     const result = await fetchResources(query, organisationFilters, themeFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should return no data when neither the query nor the organisation filter nor the theme filter matches", async () => {
-//     const query = "nonexistentquery";
-//     const organisationFilters = "non-existent-theme";
-//     const themeFilters = ["nonexistent-organisation"];
-//     const expectedData = mockData.data.filter((resource) => {
-//         const matchesQuery = Object.values(resource).some(
-//             (value) => value?.toString().toLowerCase().includes(query)
-//         );
-//         const matchesOrgFilter = resource.organisation.slug.toLowerCase() === organisationFilters.toLowerCase();
-//         const matchesThemeFilter = resource.theme === themeFilters;
-
-//         return matchesQuery || matchesThemeFilter || matchesOrgFilter;
-//     });
-//     expect(expectedData.length).toBe(0);
-
-//     const result = await fetchResources(query, undefined, themeFilters);
-//     expect(result.resources).toEqual(expectedData);
-//     expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/catalogue`);
-//   });
-
-//   it("should throw an error when the axios request fails", async () => {
-//     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
-//     await expect(fetchResources("test")).rejects.toThrow("An error occurred while fetching data from the API");
-//   });
-// });
-
-// describe("fetchResourceById", () => {
-//   beforeEach(() => {
-//     // Set up the axios get mock before each test
-//     process.env.API_ENDPOINT = "http://mock-test.endpoint.com/";
-//     mockedAxios.get.mockResolvedValue({ data: singleMockData });
-//   });
-
-//   afterEach(() => {
-//     // Clear the mock after each test
-//     mockedAxios.get.mockClear();
-//     delete process.env.API_ENDPOINT;
-//   });
-
-//   it("should return the correct resource data when valid ID is provided", async () => {
-//     const resourceId = singleMockData.asset.identifier;
-//     const expectedResource = singleMockData.asset;
-//     const result = await fetchResourceById(resourceId);
-
-//     expect(result).toEqual(expectedResource);
-//   });
-
-//   it("should throw an error when the provided ID does not exist", async () => {
-//     const resourceId = "non-existing-id";
-//     mockedAxios.get.mockResolvedValue({ data: { asset: null } });
-//     await expect(fetchResourceById(resourceId)).rejects.toThrow("Resource not found.");
-//   });
-
-//   it("should throw an error when the axios request fails", async () => {
-//     const resourceId = mockData.data[0].identifier;
-//     mockedAxios.get.mockRejectedValue(new Error("An error occurred while fetching data from the API"));
-//     await expect(fetchResourceById(resourceId)).rejects.toThrow("An error occurred while fetching data from the API");
-//   });
-// });
+    expect(response.status).toBe(500);
+    expect(response.text).toContain(
+      "Sorry, there is a problem with the service - Data Marketplace - GOV.UK",
+    );
+  });
+});

--- a/__tests__/findService.test.ts
+++ b/__tests__/findService.test.ts
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { fetchResources, fetchResourceById } from "../src/services/findService";
+
+jest.mock("axios");
+
+describe("fetchResources", () => {
+  beforeEach(() => {
+    process.env.API_ENDPOINT = "https://example.com/my-example-api";
+  });
+  it("should fetch resources with query and filters", async () => {
+    const responseData = {
+      data: {
+        data: [
+          { id: 1, name: "Resource 1" },
+          { id: 2, name: "Resource 2" },
+        ],
+      },
+    };
+    (axios.get as jest.Mock).mockResolvedValue(responseData);
+
+    const result = await fetchResources("exampleQuery", ["org1"], ["theme1"]);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("query=exampleQuery"),
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("organisation=org1"),
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("topic=theme1"),
+    );
+
+    expect(result.resources.length).toBe(2);
+  });
+
+  it("should throw an error when API_ENDPOINT is undefined", async () => {
+    process.env.API_ENDPOINT = "";
+
+    await expect(fetchResources()).rejects.toThrow(
+      "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
+    );
+  });
+
+  it("should fetch a resource by ID", async () => {
+    const resourceId = "123";
+    const responseData = {
+      data: {
+        asset: { id: resourceId, title: "Resource 123" },
+      },
+    };
+    (axios.get as jest.Mock).mockResolvedValue(responseData);
+
+    const result = await fetchResourceById(resourceId);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining(`/catalogue/${resourceId}`),
+    );
+    expect(result.title).toBe("Resource 123");
+  });
+
+  it("should throw an error when API_ENDPOINT is undefined", async () => {
+    process.env.API_ENDPOINT = "";
+
+    await expect(fetchResourceById("123")).rejects.toThrow(
+      "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
+    );
+  });
+
+  it("should throw an error when resource is not found", async () => {
+    process.env.API_ENDPOINT = "https://example.com/my-example-api";
+    const resourceId = "456";
+    (axios.get as jest.Mock).mockResolvedValue({ data: { asset: null } });
+
+    await expect(fetchResourceById(resourceId)).rejects.toThrow(
+      "Resource not found.",
+    );
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -146,7 +146,6 @@ app.use("*", (req: Request, res: Response) => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   const backLink = req.headers.referer || "/";
-  console.error(err);
   res.status(500).render("error", {
     status: 500,
     messageTitle: "Sorry, there is a problem with the service",

--- a/src/routes/findRoutes.ts
+++ b/src/routes/findRoutes.ts
@@ -11,11 +11,18 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
   const backLink = req.session.backLink || "/";
   req.session.backLink = req.originalUrl;
   const query: string | undefined = (req.query.q as string)?.toLowerCase();
-  const organisationFilters: string[] | undefined = req.query
+  let organisationFilters: string[] | undefined = req.query
     .organisationFilters as string[] | undefined;
-  const themeFilters: string[] | undefined = req.query.themeFilters as
+  let themeFilters: string[] | undefined = req.query.themeFilters as
     | string[]
     | undefined;
+
+  if (typeof organisationFilters === "string") {
+    organisationFilters = [organisationFilters];
+  }
+  if (typeof themeFilters === "string") {
+    themeFilters = [themeFilters];
+  }
 
   try {
     // Fetch the data from the API

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -14,10 +14,9 @@ export async function fetchResources(
 ): Promise<{
   resources: CatalogueItem[];
 }> {
-  const orgSearch = organisationFilters
-    ? `&organisation=${organisationFilters}`
-    : "";
-  const topicSearch = themeFilters ? `&topic=${themeFilters}` : "";
+  const orgSearch =
+    organisationFilters?.map((o) => `&organisation=${o}`).join("") || "";
+  const topicSearch = themeFilters?.map((t) => `&topic=${t}`).join("") || "";
   const apiUrl = `${process.env.API_ENDPOINT}/catalogue?query=${
     query ? query : ""
   }${orgSearch}${topicSearch}`;
@@ -26,6 +25,7 @@ export async function fetchResources(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
     );
   }
+
   const response = await axios.get<ApiResponse>(apiUrl as string);
   const resources = response.data.data;
 

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -24,7 +24,7 @@ export async function fetchResources(
     query ? query : ""
   }${orgSearch}${topicSearch}`;
   console.log(apiUrl);
-  if (!apiUrl) {
+  if (!process.env.API_ENDPOINT) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
     );
@@ -41,7 +41,7 @@ export async function fetchResourceById(
   resourceID: string,
 ): Promise<CatalogueItem> {
   const apiUrl = `${process.env.API_ENDPOINT}/catalogue/${resourceID}`;
-  if (!apiUrl) {
+  if (!process.env.API_ENDPOINT) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
     );

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -15,7 +15,6 @@ export async function fetchResources(
 ): Promise<{
   resources: CatalogueItem[];
 }> {
-  console.log(query, organisationFilters, themeFilters, filterOptionTags);
   const orgSearch = organisationFilters
     ? `&organisation=${organisationFilters}`
     : "";
@@ -23,7 +22,6 @@ export async function fetchResources(
   const apiUrl = `${process.env.API_ENDPOINT}/catalogue?query=${
     query ? query : ""
   }${orgSearch}${topicSearch}`;
-  console.log(apiUrl);
   if (!process.env.API_ENDPOINT) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -11,7 +11,6 @@ export async function fetchResources(
   query?: string,
   organisationFilters?: string[],
   themeFilters?: string[],
-  filterOptionTags?: string[],
 ): Promise<{
   resources: CatalogueItem[];
 }> {

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -14,67 +14,26 @@ export async function fetchResources(
   filterOptionTags?: string[],
 ): Promise<{
   resources: CatalogueItem[];
-  uniqueOrganisations: Organisation[];
-  uniqueThemes: string[];
-  selectedFilters?: string[];
 }> {
-  const apiUrl = `${process.env.API_ENDPOINT}/catalogue`;
+  console.log(query, organisationFilters, themeFilters, filterOptionTags);
+  const orgSearch = organisationFilters
+    ? `&organisation=${organisationFilters}`
+    : "";
+  const topicSearch = themeFilters ? `&topic=${themeFilters}` : "";
+  const apiUrl = `${process.env.API_ENDPOINT}/catalogue?query=${
+    query ? query : ""
+  }${orgSearch}${topicSearch}`;
+  console.log(apiUrl);
   if (!apiUrl) {
     throw new Error(
       "API endpoint is undefined. Please set the API_ENDPOINT environment variable.",
     );
   }
   const response = await axios.get<ApiResponse>(apiUrl as string);
-  let resources = response.data.data;
-  // Search the data if query is present
-  if (query) {
-    resources = resources.filter((catalogueItem) => {
-      return Object.values(catalogueItem).some(
-        (value) => value?.toString().toLowerCase().includes(query),
-      );
-    });
-  }
-
-  // Extract unique organisations
-  const organisationsSet = new Set();
-  const uniqueOrganisations: Organisation[] = [];
-  resources.forEach((item) => {
-    if (item.organisation && !organisationsSet.has(item.organisation.slug)) {
-      uniqueOrganisations.push(item.organisation);
-      organisationsSet.add(item.organisation.slug);
-    }
-  });
-
-  // Extract unique themes
-  const themesSet = new Set<string>();
-  resources.forEach((item) => {
-    if (item.theme && Array.isArray(item.theme)) {
-      item.theme.forEach((theme) => {
-        themesSet.add(theme);
-      });
-    }
-  });
-  const uniqueThemes = Array.from(themesSet);
-  if (organisationFilters) {
-    resources = resources.filter(
-      (item) =>
-        item.organisation &&
-        organisationFilters.includes(item.organisation.slug),
-    );
-  }
-
-  if (themeFilters) {
-    resources = resources.filter(
-      (item) =>
-        item.theme && item.theme.some((theme) => themeFilters.includes(theme)),
-    );
-  }
+  const resources = response.data.data;
 
   return {
-    resources: resources,
-    uniqueOrganisations: uniqueOrganisations,
-    uniqueThemes: uniqueThemes,
-    selectedFilters: filterOptionTags,
+    resources,
   };
 }
 


### PR DESCRIPTION
This PR ensures we are using the python api on the find page.
**Needs some discussion to align before merging.**
For example:
Multiple filters currently dont work using express default `organisationFilters=department-for-business-and-trade&organisationFilters=department-for-work-pensions` -> api call `query=&organisation=department-for-business-and-trade,department-for-work-pensions`
Searching `address` returns one result, searching `postcode` returns none.