### PR TITLE
Api proxy

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import marked from "marked";
 import helmet from "helmet";
 import homeRoute from "./routes/homeRoute";
 import learnRoutes from "./routes/learnRoutes";
+import adminRoutes from "./routes/adminRoutes";
 import findRoutes from "./routes/findRoutes";
 import shareRoutes from "./routes/shareRoutes";
 import acquirerRoutes from "./routes/acquirerRoutes";
@@ -127,6 +128,7 @@ app.use("/acquirer", acquirerRoutes);
 app.use("/manage-shares", manageRoutes);
 app.use("/cookie-settings", cookieRoutes);
 app.use("/learn", learnRoutes);
+app.use("/admin", adminRoutes);
 
 // Error handling
 // Catch all route to handle errors

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,0 +1,61 @@
+import express, { NextFunction, Request, Response } from "express";
+import axios from "axios";
+
+const router = express.Router();
+
+const API = (path: string) => `${process.env.API_ENDPOINT}/${path}`
+
+export const apiKeyMiddleware = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+) => {
+    let apiKey = req.headers['x-api-key'];
+    if (Array.isArray(apiKey)) {
+        apiKey = apiKey[0]
+    }
+
+    if (!apiKey) {
+        return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    req.apiKey = apiKey;
+    next();
+}
+
+router.use(apiKeyMiddleware);
+
+const callApiAsAdmin = async (req: Request, res: Response, path: string, verb: "GET" | "PUT" = "GET", data: any = {}) => {
+    try {
+        let response;
+        if (verb === "GET") {
+            response = await axios.get(API(path), { headers: { "x-api-key": req.apiKey } })
+        } else {
+            response = await axios.put(API(path), { ...data }, { headers: { "x-api-key": req.apiKey } })
+        }
+        return res.status(200).json(response.data)
+    } catch (error: unknown) {
+        console.error("Error getting users");
+        if (axios.isAxiosError(error)) {
+            return res.status(error.response?.status || 401).send(error.response?.data.detail)
+        } else {
+            return res.status(401).send("Unauthorised")
+        }
+    }
+}
+
+router.get("/users", async (req: Request, res: Response) => {
+    return await callApiAsAdmin(req, res, "users")
+})
+
+router.get("/users/:userId", async (req: Request, res: Response) => {
+    const userId = req.params.userId
+    return await callApiAsAdmin(req, res, `users/${userId}`)
+})
+
+router.put("/users/:userId/org", async (req: Request, res: Response) => {
+    const userId = req.params.userId
+    return await callApiAsAdmin(req, res, `users/${userId}/org`, "PUT", { ...req.body })
+})
+
+export default router;

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -3,60 +3,71 @@ import axios from "axios";
 
 const router = express.Router();
 
-const API = (path: string) => `${process.env.API_ENDPOINT}/${path}`
+const API = (path: string) => `${process.env.API_ENDPOINT}/${path}`;
 
 const apiKeyMiddleware = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
+  req: Request,
+  res: Response,
+  next: NextFunction,
 ) => {
-    let apiKey = req.headers['x-api-key'];
-    if (Array.isArray(apiKey)) {
-        apiKey = apiKey[0]
-    }
+  let apiKey = req.headers["x-api-key"];
+  if (Array.isArray(apiKey)) {
+    apiKey = apiKey[0];
+  }
 
-    if (!apiKey) {
-        return res.status(401).json({ error: 'Unauthorized' });
-    }
+  if (!apiKey) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
 
-    req.apiKey = apiKey;
-    next();
-}
+  req.apiKey = apiKey;
+  next();
+};
 
 router.use(apiKeyMiddleware);
 
-const callApiAsAdmin = async (req: Request, res: Response, path: string, verb: "GET" | "PUT" = "GET", data: any = {}) => {
-    const headers = { "x-api-key": req.apiKey }
-    try {
-        let response;
-        if (verb === "GET") {
-            response = await axios.get(API(path), { headers })
-        } else {
-            response = await axios.put(API(path), { ...data }, { headers })
-        }
-        return res.status(200).json(response.data)
-    } catch (error: unknown) {
-        console.error("Error getting users");
-        if (axios.isAxiosError(error)) {
-            return res.status(error.response?.status || 401).send(error.response?.data.detail)
-        } else {
-            return res.status(401).send("Unauthorised")
-        }
+const callApiAsAdmin = async (
+  req: Request,
+  res: Response,
+  path: string,
+  verb: "GET" | "PUT" = "GET",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any = {},
+) => {
+  const headers = { "x-api-key": req.apiKey };
+  try {
+    let response;
+    if (verb === "GET") {
+      response = await axios.get(API(path), { headers });
+    } else {
+      response = await axios.put(API(path), { ...data }, { headers });
     }
-}
+    return res.status(200).json(response.data);
+  } catch (error: unknown) {
+    console.error("Error getting users");
+    if (axios.isAxiosError(error)) {
+      return res
+        .status(error.response?.status || 401)
+        .send(error.response?.data.detail);
+    } else {
+      return res.status(401).send("Unauthorised");
+    }
+  }
+};
 
 router.get("/users", async (req: Request, res: Response) => {
-    return await callApiAsAdmin(req, res, "users")
-})
+  return await callApiAsAdmin(req, res, "users");
+});
 
 router.get("/users/:userId", async (req: Request, res: Response) => {
-    const userId = req.params.userId
-    return await callApiAsAdmin(req, res, `users/${userId}`)
-})
+  const userId = req.params.userId;
+  return await callApiAsAdmin(req, res, `users/${userId}`);
+});
 
 router.put("/users/:userId/org", async (req: Request, res: Response) => {
-    const userId = req.params.userId
-    return await callApiAsAdmin(req, res, `users/${userId}/org`, "PUT", { ...req.body })
-})
+  const userId = req.params.userId;
+  return await callApiAsAdmin(req, res, `users/${userId}/org`, "PUT", {
+    ...req.body,
+  });
+});
 
 export default router;

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -5,7 +5,7 @@ const router = express.Router();
 
 const API = (path: string) => `${process.env.API_ENDPOINT}/${path}`
 
-export const apiKeyMiddleware = async (
+const apiKeyMiddleware = async (
     req: Request,
     res: Response,
     next: NextFunction,
@@ -26,12 +26,13 @@ export const apiKeyMiddleware = async (
 router.use(apiKeyMiddleware);
 
 const callApiAsAdmin = async (req: Request, res: Response, path: string, verb: "GET" | "PUT" = "GET", data: any = {}) => {
+    const headers = { "x-api-key": req.apiKey }
     try {
         let response;
         if (verb === "GET") {
-            response = await axios.get(API(path), { headers: { "x-api-key": req.apiKey } })
+            response = await axios.get(API(path), { headers })
         } else {
-            response = await axios.put(API(path), { ...data }, { headers: { "x-api-key": req.apiKey } })
+            response = await axios.put(API(path), { ...data }, { headers })
         }
         return res.status(200).json(response.data)
     } catch (error: unknown) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -198,6 +198,7 @@ interface Section {
 declare module "express-serve-static-core" {
   interface Request {
     user: UserData;
+    apiKey: string;
   }
 }
 


### PR DESCRIPTION
# Proxy for admin routes
The Python API has some endpoints that we can use to manually edit users accounts, and soon will have endpoints for manually setting users' permissions. Originally I thought we'd just be able to call the API directly, but Soydaner suggested that it might be tricky to open up the python API so that we could send requests to it directly without of going through the frontend.

So this PR adds some admin routes that get passed straight through to the python API and return whatever JSON data the API produces.
All admin routes require that an `x-api-key` header is set.