### PR TITLE
Dmbm 844/manage data share completed and accepted

### DIFF
--- a/src/routes/learnRoutes.ts
+++ b/src/routes/learnRoutes.ts
@@ -23,9 +23,12 @@ router.get(
   },
 );
 
-router.get("/adding-a-single-data-asset", async (req: Request, res: Response) => {
-  res.render("../views/learn/adding-a-single-data-asset.njk");
-});
+router.get(
+  "/adding-a-single-data-asset",
+  async (req: Request, res: Response) => {
+    res.render("../views/learn/adding-a-single-data-asset.njk");
+  },
+);
 
 router.get("/guidance-on-publish", async (req: Request, res: Response) => {
   res.render("../views/learn/guidance-on-publish.njk");

--- a/src/routes/profileRoutes.ts
+++ b/src/routes/profileRoutes.ts
@@ -13,7 +13,9 @@ router.get(
 
     let requestForms = {};
     try {
-      const response = await axios.get(URL, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
+      const response = await axios.get(URL, {
+        headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
+      });
       requestForms = response.data["sharedata"] || {};
       req.session.acquirerForms = requestForms;
     } catch (error) {

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -2,26 +2,40 @@ import express, { Request, Response } from "express";
 import { DateStep, ManageShareTableRow } from "../types/express";
 import axios from "axios";
 const router = express.Router();
-const URL = `${process.env.API_ENDPOINT}/manage-shares/received-requests`
+const URL = `${process.env.API_ENDPOINT}/manage-shares/received-requests`;
 
 const formatDate = (dateString: string): string => {
-  const options: Intl.DateTimeFormatOptions = { 
-      year: 'numeric', 
-      month: 'long', 
-      day: 'numeric' 
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
   };
   return new Date(dateString).toLocaleDateString(undefined, options);
-}
+};
 
-function formatDateObject(dateObj: { day: string, month: string, year: string }): string {
+function formatDateObject(dateObj: {
+  day: string;
+  month: string;
+  year: string;
+}): string {
   const monthNames = [
-      "January", "February", "March", "April", "May", "June",
-      "July", "August", "September", "October", "November", "December"
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
   ];
-  
+
   const monthIndex = parseInt(dateObj.month, 10) - 1; // Convert month string to number and subtract 1 for zero-based index
   const monthName = monthNames[monthIndex];
-  
+
   return `${dateObj.day} ${monthName} ${dateObj.year}`;
 }
 
@@ -123,165 +137,215 @@ router.get("/created-requests", async (req: Request, res: Response) => {
 router.get("/received-requests", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/manage-shares";
 
-  const response = await axios.get(URL, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
+  const response = await axios.get(URL, {
+    headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
+  });
   const receivedTableRows = [];
   if (response.data && response.data.length > 0) {
     for (const request of response.data) {
       // Format the received date
       request.received = formatDate(request.received);
-      
-      // Format the "Needed by" date on the 
-      if (request.sharedata && request.sharedata.steps && request.sharedata.steps.date) {
+
+      // Format the "Needed by" date on the
+      if (
+        request.sharedata &&
+        request.sharedata.steps &&
+        request.sharedata.steps.date
+      ) {
         const dateObj = request.sharedata.steps.date.value;
         request.sharedata.steps.date.formattedValue = formatDateObject(dateObj);
       }
 
-      console.log(request.sharedata)
       const row = [
-        { html: `<a href="/manage-shares/received-requests/${request.requestId}">${request.requestId}</a>` }, 
+        {
+          html: `<a href="/manage-shares/received-requests/${request.requestId}">${request.requestId}</a>`,
+        },
         { text: request.requesterEmail },
         { text: request.assetTitle },
         { text: request.received },
         { text: request.sharedata.steps.date.formattedValue },
-        { html: `<span class="govuk-tag ${getStatusClass(request.status)}">${request.status}</span>` },
+        {
+          html: `<span class="govuk-tag ${getStatusClass(request.status)}">${
+            request.status
+          }</span>`,
+        },
       ];
       receivedTableRows.push(row);
     }
   } else {
-      receivedTableRows.push([{ text: "No received requests.", colspan: 6 }]);
+    receivedTableRows.push([{ text: "No received requests.", colspan: 6 }]);
   }
 
   res.render("../views/supplier/received-requests.njk", {
-      backLink,
-      receivedTableRows: receivedTableRows,
+    backLink,
+    receivedTableRows: receivedTableRows,
   });
 });
 
-router.get("/received-requests/:requestId", async (req: Request, res: Response) => {
-  const backLink = req.headers.referer || "/manage-shares/received-requests/";
-  const requestId = req.params.requestId;
-  
-  try {
-    const requestDetail = await axios.get(`${URL}/${requestId}`, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
+router.get(
+  "/received-requests/:requestId",
+  async (req: Request, res: Response) => {
+    const backLink = req.headers.referer || "/manage-shares/received-requests/";
+    const requestId = req.params.requestId;
 
-    if (!requestDetail.data) {
-        return res.status(404).send('Request not found');
+    try {
+      const requestDetail = await axios.get(`${URL}/${requestId}`, {
+        headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
+      });
+
+      if (!requestDetail.data) {
+        return res.status(404).send("Request not found");
+      }
+
+      // Format the received date
+      requestDetail.data.received = formatDate(requestDetail.data.received);
+
+      // Format the neededBy date
+      const dateObj = requestDetail.data.sharedata.steps.date.value;
+      requestDetail.data.sharedata.steps.date.formattedValue =
+        formatDateObject(dateObj);
+
+      req.session.acquirerForms = requestDetail.data;
+
+      res.render("../views/supplier/review-summary.njk", {
+        backLink,
+        request: requestDetail.data,
+      });
+    } catch (error) {
+      console.error(error);
+      res.status(500).send("Internal Server Error");
+    }
+  },
+);
+
+router.post(
+  "/received-requests/:requestId",
+  async (req: Request, res: Response) => {
+    const requestId = req.params.requestId;
+    res.redirect(
+      `/manage-shares/received-requests/${requestId}/review-request`,
+    );
+  },
+);
+
+router.get(
+  "/received-requests/:requestId/review-request",
+  (req: Request, res: Response) => {
+    const requestDetail = req.session.acquirerForms;
+
+    if (!requestDetail) {
+      return res.status(404).send("Request data not found in session");
     }
 
-    // Format the received date
-    requestDetail.data.received = formatDate(requestDetail.data.received);
-
-    // Format the neededBy date
-    const dateObj = requestDetail.data.sharedata.steps.date.value;
-    requestDetail.data.sharedata.steps.date.formattedValue = formatDateObject(dateObj);
-
-    req.session.acquirerForms = requestDetail.data;
-
-    res.render("../views/supplier/review-summary.njk", {
-      backLink,
-      request: requestDetail.data
+    res.render("../views/supplier/review-request.njk", {
+      request: requestDetail,
     });
-  } catch (error) {
-    console.error(error);
-    res.status(500).send('Internal Server Error');
-  }
-});
+  },
+);
 
-router.post("/received-requests/:requestId", async (req: Request, res: Response) => {
-  const requestId = req.params.requestId;
-  res.redirect(`/manage-shares/received-requests/${requestId}/review-request`);
-});
+router.post(
+  "/received-requests/:requestId/review-request",
+  async (req: Request, res: Response) => {
+    const requestId = req.params.requestId;
 
-router.get("/received-requests/:requestId/review-request", (req: Request, res: Response) => { 
-  const requestDetail = req.session.acquirerForms;
+    if (req.body.continueButton) {
+      return res.redirect(
+        `/manage-shares/received-requests/${requestId}/decision`,
+      );
+    } else if (req.body.returnButton) {
+      return res.redirect("/manage-shares/review-summary");
+    }
+  },
+);
 
-  if (!requestDetail) {
-    return res.status(404).send('Request data not found in session');
-  }
+router.get(
+  "/received-requests/:requestId/decision",
+  async (req: Request, res: Response) => {
+    const backLink = req.headers.referer || "/";
+    const requestId = req.params.requestId;
 
-  console.log("requestDetail from session", requestDetail);
-  res.render("../views/supplier/review-request.njk", {
-    request: requestDetail
-  });
-});
+    res.render("../views/supplier/decision.njk", {
+      backLink,
+      requestId,
+    });
+  },
+);
 
-router.post("/received-requests/:requestId/review-request", async (req: Request, res: Response) => {
-  const requestId = req.params.requestId;
+router.post(
+  "/received-requests/:requestId/decision",
+  async (req: Request, res: Response) => {
+    const requestId = req.params.requestId;
 
-  if (req.body.continueButton) {
-    return res.redirect(`/manage-shares/received-requests/${requestId}/decision`);
-  } else if (req.body.returnButton) {
-    return res.redirect("/manage-shares/review-summary");
-  }
-});
+    const decision = req.body.decision;
 
-router.get("/received-requests/:requestId/decision", async (req: Request, res: Response) => {
-  const backLink = req.headers.referer || "/";
-  const requestId = req.params.requestId;
+    if (decision === "return") {
+      return res.redirect("/manage-shares/return-request");
+    }
 
-  res.render("../views/supplier/decision.njk", {
-    backLink,
-    requestId
-  });
-});
+    if (decision === "approve") {
+      return res.redirect(
+        `/manage-shares/received-requests/${requestId}/declaration`,
+      );
+    }
 
-router.post("/received-requests/:requestId/decision", async (req: Request, res: Response) => {
-  const requestId = req.params.requestId;
+    if (decision === "reject") {
+      return res.redirect("/manage-shares/reject-request");
+    }
 
-  const decision = req.body.decision;
+    return res.redirect("/manage-shares/received-requests");
+  },
+);
 
-  if (decision === "return") {
-    return res.redirect("/manage-shares/return-request");
-  }
+router.get(
+  "/received-requests/:requestId/declaration",
+  async (req: Request, res: Response) => {
+    const requestId = req.params.requestId;
+    res.render("../views/supplier/declaration.njk", {
+      requestId,
+    });
+  },
+);
 
-  if (decision === "approve") {
-    console.log(req.body)
-    return res.redirect(`/manage-shares/received-requests/${requestId}/declaration`);
-  }
+router.post(
+  "/received-requests/:requestId/declaration",
+  async (req: Request, res: Response) => {
+    const requestId = req.params.requestId;
 
-  if (decision === "reject") {
-    return res.redirect("/manage-shares/reject-request");
-  }
+    if (req.body.acceptButton) {
+      return res.redirect(
+        `/manage-shares/received-requests/${requestId}/accept-request`,
+      );
+    }
+    return res.redirect("/manage-shares/received-requests");
+  },
+);
 
-  return res.redirect("/manage-shares/received-requests");
-});
+router.get(
+  "/received-requests/:requestId/accept-request",
+  (req: Request, res: Response) => {
+    const backLink = req.headers.referer || "/";
+    const requestId = req.params.requestId;
+    const requestData = req.session.acquirerForms;
 
-router.get("/received-requests/:requestId/declaration", async (req: Request, res: Response) => {
-  const requestId = req.params.requestId;
-  res.render("../views/supplier/declaration.njk", {
-    requestId,
-  });
-});
+    if (!requestData) {
+      return res.status(404).send("Request data not found");
+    }
 
-router.post("/received-requests/:requestId/declaration", async (req: Request, res: Response) => {
-  const requestId = req.params.requestId;
+    res.render("../views/supplier/accept-request.njk", {
+      backLink,
+      requestId,
+      requestingOrg: requestData.requestingOrg,
+      requesterEmail: requestData.requesterEmail,
+    });
+  },
+);
 
-  if (req.body.acceptButton) {
-    return res.redirect(`/manage-shares/received-requests/${requestId}/accept-request`);
-  }
-  return res.redirect("/manage-shares/received-requests");
-});
-
-router.get("/received-requests/:requestId/accept-request", (req: Request, res: Response) => {
-  const backLink = req.headers.referer || "/";
-  const requestId = req.params.requestId;
-  const requestData = req.session.acquirerForms;
-
-  if (!requestData) {
-    return res.status(404).send('Request data not found');
-  }
-
-  res.render("../views/supplier/accept-request.njk", {
-    backLink,
-    requestId,
-    requestingOrg: requestData.requestingOrg,
-    requesterEmail: requestData.requesterEmail
-  });
-});
-
-router.post("/received-requests/:requestId/accept-request", async (req: Request, res: Response) => {
-  return res.redirect("/manage-shares/received-requests");
-});
+router.post(
+  "/received-requests/:requestId/accept-request",
+  async (req: Request, res: Response) => {
+    return res.redirect("/manage-shares/received-requests");
+  },
+);
 
 router.get("/reject-request", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
@@ -310,16 +374,15 @@ router.post("/return-request", async (req: Request, res: Response) => {
 router.get("/request-accepted", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
   res.render("../views/supplier/request-accepted.njk", {
-    backLink
+    backLink,
   });
 });
 
 router.get("/request-rejected", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
   res.render("../views/supplier/request-rejected.njk", {
-    backLink
+    backLink,
   });
 });
-
 
 export default router;

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -157,12 +157,12 @@ router.get("/received-requests", async (req: Request, res: Response) => {
   });
 });
 
-router.get("/received-requests/:resourceId", async (req: Request, res: Response) => {
+router.get("/received-requests/:requestId", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/manage-shares/received-requests/";
-  const resourceId = req.params.resourceId;
+  const requestId = req.params.requestId;
   
   try {
-    const requestDetail = await axios.get(`${URL}/${resourceId}`, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
+    const requestDetail = await axios.get(`${URL}/${requestId}`, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
 
     if (!requestDetail.data) {
         return res.status(404).send('Request not found');
@@ -183,11 +183,12 @@ router.get("/received-requests/:resourceId", async (req: Request, res: Response)
   }
 });
 
-router.post("/received-requests/:resourceId", async (req: Request, res: Response) => {
-  const resourceId = req.params.resourceId;
-  res.redirect(`/manage-shares/received-requests/${resourceId}/review-request`);
+router.post("/received-requests/:requestId", async (req: Request, res: Response) => {
+  const requestId = req.params.requestId;
+  res.redirect(`/manage-shares/received-requests/${requestId}/review-request`);
 });
-router.get("/received-requests/:resourceId/review-request", (req: Request, res: Response) => { 
+
+router.get("/received-requests/:requestId/review-request", (req: Request, res: Response) => { 
   const requestDetail = req.session.acquirerForms;
 
   if (!requestDetail) {
@@ -200,28 +201,28 @@ router.get("/received-requests/:resourceId/review-request", (req: Request, res: 
   });
 });
 
-router.post("/received-requests/:resourceId/review-request", async (req: Request, res: Response) => {
-  const resourceId = req.params.resourceId;
+router.post("/received-requests/:requestId/review-request", async (req: Request, res: Response) => {
+  const requestId = req.params.requestId;
 
   if (req.body.continueButton) {
-    return res.redirect(`/manage-shares/received-requests/${resourceId}/decision`);
+    return res.redirect(`/manage-shares/received-requests/${requestId}/decision`);
   } else if (req.body.returnButton) {
     return res.redirect("/manage-shares/review-summary");
   }
 });
 
-router.get("/received-requests/:resourceId/decision", async (req: Request, res: Response) => {
+router.get("/received-requests/:requestId/decision", async (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
-  const resourceId = req.params.resourceId;
+  const requestId = req.params.requestId;
 
   res.render("../views/supplier/decision.njk", {
     backLink,
-    resourceId
+    requestId
   });
 });
 
-router.post("/received-requests/:resourceId/decision", async (req: Request, res: Response) => {
-  const resourceId = req.params.resourceId;
+router.post("/received-requests/:requestId/decision", async (req: Request, res: Response) => {
+  const requestId = req.params.requestId;
 
   const decision = req.body.decision;
 
@@ -231,7 +232,7 @@ router.post("/received-requests/:resourceId/decision", async (req: Request, res:
 
   if (decision === "approve") {
     console.log(req.body)
-    return res.redirect(`/manage-shares/received-requests/${resourceId}/declaration`);
+    return res.redirect(`/manage-shares/received-requests/${requestId}/declaration`);
   }
 
   if (decision === "reject") {
@@ -241,25 +242,25 @@ router.post("/received-requests/:resourceId/decision", async (req: Request, res:
   return res.redirect("/manage-shares/received-requests");
 });
 
-router.get("/received-requests/:resourceId/declaration", async (req: Request, res: Response) => {
-  const resourceId = req.params.resourceId;
+router.get("/received-requests/:requestId/declaration", async (req: Request, res: Response) => {
+  const requestId = req.params.requestId;
   res.render("../views/supplier/declaration.njk", {
-    resourceId,
+    requestId,
   });
 });
 
-router.post("/received-requests/:resourceId/declaration", async (req: Request, res: Response) => {
-  const resourceId = req.params.resourceId;
+router.post("/received-requests/:requestId/declaration", async (req: Request, res: Response) => {
+  const requestId = req.params.requestId;
 
   if (req.body.acceptButton) {
-    return res.redirect(`/manage-shares/received-requests/${resourceId}/accept-request`);
+    return res.redirect(`/manage-shares/received-requests/${requestId}/accept-request`);
   }
   return res.redirect("/manage-shares/received-requests");
 });
 
-router.get("/received-requests/:resourceId/accept-request", (req: Request, res: Response) => {
+router.get("/received-requests/:requestId/accept-request", (req: Request, res: Response) => {
   const backLink = req.headers.referer || "/";
-  const resourceId = req.params.resourceId;
+  const requestId = req.params.requestId;
   const requestData = req.session.acquirerForms;
 
   if (!requestData) {
@@ -268,13 +269,13 @@ router.get("/received-requests/:resourceId/accept-request", (req: Request, res: 
 
   res.render("../views/supplier/accept-request.njk", {
     backLink,
-    resourceId,
+    requestId,
     requestingOrg: requestData.requestingOrg,
     requesterEmail: requestData.requesterEmail
   });
 });
 
-router.post("/received-requests/:resourceId/accept-request", async (req: Request, res: Response) => {
+router.post("/received-requests/:requestId/accept-request", async (req: Request, res: Response) => {
   return res.redirect("/manage-shares/received-requests");
 });
 

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -125,18 +125,18 @@ router.get("/received-requests", async (req: Request, res: Response) => {
 
   const response = await axios.get(URL, { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } });
   const receivedTableRows = [];
-  // console.log(response)
   if (response.data && response.data.length > 0) {
     for (const request of response.data) {
       // Format the received date
       request.received = formatDate(request.received);
       
-      // Format the "Needed by" date
+      // Format the "Needed by" date on the 
       if (request.sharedata && request.sharedata.steps && request.sharedata.steps.date) {
         const dateObj = request.sharedata.steps.date.value;
         request.sharedata.steps.date.formattedValue = formatDateObject(dateObj);
       }
-      
+
+      console.log(request.sharedata)
       const row = [
         { html: `<a href="/manage-shares/received-requests/${request.requestId}">${request.requestId}</a>` }, 
         { text: request.requesterEmail },
@@ -168,10 +168,14 @@ router.get("/received-requests/:requestId", async (req: Request, res: Response) 
         return res.status(404).send('Request not found');
     }
 
+    // Format the received date
     requestDetail.data.received = formatDate(requestDetail.data.received);
 
+    // Format the neededBy date
+    const dateObj = requestDetail.data.sharedata.steps.date.value;
+    requestDetail.data.sharedata.steps.date.formattedValue = formatDateObject(dateObj);
 
-    req.session.acquirerForms = requestDetail.data
+    req.session.acquirerForms = requestDetail.data;
 
     res.render("../views/supplier/review-summary.njk", {
       backLink,

--- a/src/stylesheets/application.scss
+++ b/src/stylesheets/application.scss
@@ -99,7 +99,7 @@ aside {
 }
 
 .learn-images {
-  max-width:100%;
-  height:auto;
-  border:1px solid grey;
+  max-width: 100%;
+  height: auto;
+  border: 1px solid grey;
 }

--- a/src/views/supplier/accept-request.njk
+++ b/src/views/supplier/accept-request.njk
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     {{ govukPanel({
         titleText: "Request accepted",
-        html: resourceId 
+        html: requestId 
     }) }}
     <p class="govuk-body">{{ requestingOrg }} has been told their request has been accepted and you will contact them to discuss further.</p>
     <h2 class="govuk-heading-m">What happens next</h2>

--- a/src/views/supplier/accept-request.njk
+++ b/src/views/supplier/accept-request.njk
@@ -7,11 +7,11 @@
   <div class="govuk-grid-column-two-thirds">
     {{ govukPanel({
         titleText: "Request accepted",
-        html: "Request ID: RR523"
+        html: resourceId 
     }) }}
-    <p class="govuk-body">Department X has been told their request has been accepted and you will contact them to discuss further.</p>
+    <p class="govuk-body">{{ requestingOrg }} has been told their request has been accepted and you will contact them to discuss further.</p>
     <h2 class="govuk-heading-m">What happens next</h2>
-    <p class="govuk-body">Contact <a class="govuk-link" href="mailto:data-team@department-x.gov.uk">data-team@department-x.gov.uk</a> to start a discussion.</p>
+    <p class="govuk-body">Contact <a class="govuk-link" href="mailto:{{ requesterEmail }}" target="_blank">{{requesterEmail}}</a> to start a discussion.</p>
     <form method="POST" id="requestAcceptForm">
       <div class="govuk-button-group">
         {{ govukButton({

--- a/src/views/supplier/decision.njk
+++ b/src/views/supplier/decision.njk
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: RR325</span>
-    <form method="POST" id="decisionForm" action="/manage-shares/decision">
+    <span class="govuk-caption-l">Request ID: {{ resourceId }} </span>
+    <form method="POST" id="decisionForm">
       {% set ReturnWithCommentsHtml %}
         {{ govukTextarea({
           id: "return-with-comments-textarea",
@@ -79,9 +79,9 @@
       }) }}
       <div class="govuk-button-group">
         {{ govukButton({
-            text: "Submit",
-            name: "submitButton",
-            value: "submit"
+          text: "Submit",
+          name: "submitButton",
+          value: "submit"
         }) }}
         <a href="/manage-shares/received-requests" class="govuk-link">Returned to received requests</a>
       </div>

--- a/src/views/supplier/decision.njk
+++ b/src/views/supplier/decision.njk
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: {{ resourceId }} </span>
+    <span class="govuk-caption-l">Request ID: {{ requestId }} </span>
     <form method="POST" id="decisionForm">
       {% set ReturnWithCommentsHtml %}
         {{ govukTextarea({

--- a/src/views/supplier/declaration.njk
+++ b/src/views/supplier/declaration.njk
@@ -15,7 +15,7 @@
     </ul>
     <p class="govuk-body">aspects have been met.</p>
     <br>
-    <form class="form" action="/manage-shares/received-requests/{{resourceId}}/declaration" method="post">
+    <form class="form" action="/manage-shares/received-requests/{{ requestId }}/declaration" method="post">
       <div class="govuk-button-group">
         {{ govukButton({
             text: "Accept the data share request",

--- a/src/views/supplier/declaration.njk
+++ b/src/views/supplier/declaration.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Declaration</h1>
@@ -16,7 +15,7 @@
     </ul>
     <p class="govuk-body">aspects have been met.</p>
     <br>
-    <form class="form" action="/manage-shares/declaration" method="post">
+    <form class="form" action="/manage-shares/received-requests/{{resourceId}}/declaration" method="post">
       <div class="govuk-button-group">
         {{ govukButton({
             text: "Accept the data share request",
@@ -26,5 +25,4 @@
     </form>
   </div>
 </div>
-
 {% endblock %}

--- a/src/views/supplier/received-requests.njk
+++ b/src/views/supplier/received-requests.njk
@@ -45,77 +45,8 @@
                 text: "Status"
             }
             ],
-            rows: [
-            [
-                {
-                html: '<a href="/manage-shares/review-summary" class="govuk-link">RR523 - View</a>'
-                },
-                {
-                text: "Department X"
-                },
-                {
-                text: "citizen-relationships"
-                },
-                {
-                text: "8 Jul 2023"
-                },
-                {
-                text: "16 Mar 2024"
-                },
-                {
-                html: govukTag({
-                    classes: "govuk-tag--red",
-                    text: "TO REVIEW"
-                  })
-                }
-            ],
-            [
-             {
-                html: '<a href="#" class="govuk-link">RR330 - View</a>'
-                },
-            {
-            text: "Department for Work and Pensions"
-            },
-            {
-            text: "citizen-switch-input"
-            },
-            {
-            text: "	2 Jul 2023"
-            },
-            {
-            text: "16 Mar 2024"
-            },
-            {
-            html: govukTag({
-                classes: "govuk-tag--blue",
-                text: "REVIEWING"
-              })
-            }
-        ],
-        [
-            {
-                html: '<a href="#" class="govuk-link">RR221 - View</a>'
-            },
-            {
-            text: "HM Revenue and Customs"
-            },
-            {
-            text: "tax-rate-change_brackets"
-            },
-            {
-            text: "	2 Jul 2023"
-            },
-            {
-            text: "16 Mar 2024"
-            },
-            {
-            html: govukTag({
-                classes: "govuk-tag--grey",
-                text: "RETURNED"
-              })
-            }
-        ]
-        ]}) }}
+            rows: receivedTableRows
+        }) }}
   </div>
 </div>
 

--- a/src/views/supplier/review-request.njk
+++ b/src/views/supplier/review-request.njk
@@ -105,7 +105,7 @@
 
     <div class="request-section">
       <h2 class="govuk-heading-m">When they need it</h2>
-      <p class="govuk-body">{{ request.sharedata.steps.date.value.day }}/{{ request.sharedata.steps.date.value.month }}/{{ request.sharedata.steps.date.value.year }}</p>
+      <p class="govuk-body">{{ request.sharedata.steps.date.formattedValue }}</p>
     </div>
 
     <div class="request-section">
@@ -122,12 +122,14 @@
     <div class="request-section">
       <h2 class="govuk-heading-m">Data accessed by other organisations</h2>
       <p class="govuk-body">{{ request.sharedata.steps['data-access'].value | capitalize }}</p>
-      <p class="govuk-body">Organisations:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        {% for org in request.sharedata.steps['other-orgs'].value %}
-          <li>{{ org }}</li>
-        {% endfor %}
-      </ul>
+        {% if request.sharedata.steps['data-access'].value == "yes" %}
+        <p class="govuk-body">Organisations:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          {% for org in request.sharedata.steps['other-orgs'].value %}
+            <li>{{ org }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/src/views/supplier/review-request.njk
+++ b/src/views/supplier/review-request.njk
@@ -3,156 +3,169 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% block content %}
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: RR532</span>
+    <span class="govuk-caption-l">Request ID: {{ request.requestId }}</span>
     <h1 class="govuk-heading-l">
-      Review Department X's request to access citizen-relationships data
+      Review {{ request.requestingOrg }}'s request to access {{ request.assetTitle }} data
     </h1>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Lawful basis for personal data</h2>
       <ul class="govuk-list">
-        <li class="govuk-!-padding-bottom-3">Public task</li>
-        <li class="govuk-!-padding-bottom-3">Contract</li>
+        {% for basis, details in request.sharedata.steps['lawful-basis-personal'].value %}
+          {% if details.checked %}
+            <li class="govuk-!-padding-bottom-3">{{ basis | replace("-", " ") | capitalize }}</li>
+          {% endif %}
+        {% endfor %}
       </ul>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Legal power</h2>
-      <p class="govuk-body">Common law</p>
+      <p class="govuk-body">{{ request.sharedata.steps['legal-power'].value.yes.explanation }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Justification for legal gateway</h2>
       <div class="govuk-warning-text govuk-!-static-margin-bottom-2">
       </div>
-      <p class="govuk-body">
-        Under Regulation 3 of The Health Service (Control of Patient Information), patient data can be lawfully processed with a view to:<br>
-        <br>
-        * diagnosing communicable diseases and other risks to public health.<br>
-        * recognising trends in such diseases and risks.<br>
-        * controlling and preventing the spread of such diseases and risks.<br>
-        * monitoring and managing:<br>
-        ** outbreaks of communicable disease.<br>
-        ** incidents of exposure to communicable disease.<br>
-        ** the delivery, efficacy and safety of immunisation programmes.<br>
-        ** adverse reactions to vaccines and medicines.<br>
-        ** risks of infection acquired from food or the environment (including water supplies).<br>
-        ** the giving of information to persons about the diagnosis of communicable disease and risks of acquiring such disease.<br>
-      </p>
+      <p class="govuk-body">{{ request.sharedata.steps['legal-gateway'].value.yes.explanation }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data travel outside UK</h2>
-      <p class="govuk-body">No</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-travel'].value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data subjects</h2>
-      <p class="govuk-body">Clinically extremely vulnerable patients.</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-subjects'].value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Aim of project</h2>
-      <p class="govuk-body">To assess claims and provide the correct level of support to vulnerable people based on their declared family relationships.</p>
+      <p class="govuk-body">{{ request.sharedata.steps['project-aims'].value.aims }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">How data will help reach this aim</h2>
-      <p class="govuk-body">We cannot identify who needs support without access to a data set about who in the UK is clinically vulnerable.</p>
+      <p class="govuk-body">{{ request.sharedata.steps['project-aims'].value.explanation }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Public benefits of project</h2>
       <h3 class="govuk-heading-s">Evidence for public service delivery</h3>
-      <p class="govuk-body">
-        This data will allow us to identify both who to help and the number of people we need to help.</p>
+      <p class="govuk-body">{{ request.sharedata.steps.benefits.value['service-delivery'].explanation }}</p>
       <h3 class="govuk-heading-s">Evidence for decisions which are likely to benefit people in the UK</h3>
-      <p class="govuk-body">Depending on the number of people involved, this data could be used to support similar programs in the future.</p>
+      <p class="govuk-body">{{ request.sharedata.steps.benefits.value['benefit-people'].explanation }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Preferred format</h2>
-      <p class="govuk-body">CSV file</p>
+      <ul class="govuk-list">
+        {% for format, details in request.sharedata.steps.format.value %}
+          {% if details.checked %}
+            <li class="govuk-!-padding-bottom-3">{{ format |  capitalize }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">How they want to receive it</h2>
-      <p class="govuk-body">Through secure third-party software</p>
+      <ul class="govuk-list">
+        {% for method, details in request.sharedata.steps.delivery.value %}
+          {% if details.checked %}
+            <li class="govuk-!-padding-bottom-3">{{ method | capitalize }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">What they think their role is</h2>
-      <p class="govuk-body">Processor</p>
+      <p class="govuk-body">{{ request.sharedata.steps.role.value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data they want</h2>
-      <p class="govuk-body">List of vulnerable people's names and contact details</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-required'].value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">How it will impact the project if they don't get the data</h2>
-      <p class="govuk-body">The project will be impossible to complete. We are reliant on this data and have no alternatives.</p>
+      <p class="govuk-body">{{ request.sharedata.steps.impact.value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">How they will dispose of the data</h2>
-      <p class="govuk-body">Store CSV files in a secure sever and delete all files at end of project.</p>
+      <p class="govuk-body">{{ request.sharedata.steps.disposal.value }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">When they need it</h2>
-      <p class="govuk-body">16 March 2024</p>
+      <p class="govuk-body">{{ request.sharedata.steps.date.value.day }}/{{ request.sharedata.steps.date.value.month }}/{{ request.sharedata.steps.date.value.year }}</p>
     </div>
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data type</h2>
-      <p class="govuk-body">Personal data</p>
+      <ul class="govuk-list">
+        {% for type, details in request.sharedata.steps['data-type'].value %}
+          {% if details.checked %}
+            <li class="govuk-!-padding-bottom-3">{{ type | capitalize }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
     </div>
 
-    <div class="request-section" style="border-bottom: 1px solid #ccc;">
+    <div class="request-section">
       <h2 class="govuk-heading-m">Data accessed by other organisations</h2>
-      <p class="govuk-body">Yes</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-access'].value }}</p>
       <p class="govuk-body">Organisations:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>NHS</li>
+        {% for org in request.sharedata.steps['other-orgs'].value %}
+          <li>{{ org }}</li>
+        {% endfor %}
       </ul>
     </div>
   </div>
 </div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukTextarea({
+      name: "request-notes",
+      id: "request-notes",
+      label: {
+        text: "Notes (not shared with " + request.requestingOrg + ")",
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+      hint: {
+        text: "Do not include personal or financial information, like your National Insurance number or credit card details."
+      }
+    }) }}
+  </div>
+</div>
+
+
 <div class="govuk-grid-row" style="margin-top: 3em;">
   <div class="govuk-grid-column-two-thirds">
-    <form method="post" action="/manage-shares/review-request" id="reviewRequestNotesForm">
-      <div class="govuk-form-group">
-        {{ govukTextarea({
-          name: "review-request-notes",
-          id: "review-request-notes",
-          label: {
-            text: "Notes (not shared with Department X)",
-            classes: "govuk-label--l",
-            isPageHeading: true
-          }
-        }) }}
-      <div class="govuk-button-group">
-        {{ govukButton({
-            text: "Save and continue",
-            name: "continueButton",
-            value: "continue"
-        }) }}
-        {{ govukButton({
-            text: "Save and return",
-            classes: "govuk-button--secondary",
-            name: "returnButton",
-            value: "return"
-        }) }}
-      </div>
+    <form method="post">
+      {{ govukButton({
+        text: "Continue",
+        name: "continueButton"
+      }) }}
+      {{ govukButton({
+        text: "Return to summary",
+        name: "returnButton",
+        classes: "govuk-button--secondary"
+      }) }}
     </form>
   </div>
 </div>
 
+</div>
 
 {% endblock %}

--- a/src/views/supplier/review-request.njk
+++ b/src/views/supplier/review-request.njk
@@ -23,7 +23,7 @@
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Legal power</h2>
-      <p class="govuk-body">{{ request.sharedata.steps['legal-power'].value.yes.explanation }}</p>
+      <p class="govuk-body">{{ request.sharedata.steps['legal-power'].value.yes.explanation | capitalize }}</p>
     </div>
 
     <div class="request-section">
@@ -35,7 +35,7 @@
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data travel outside UK</h2>
-      <p class="govuk-body">{{ request.sharedata.steps['data-travel'].value }}</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-travel'].value | capitalize }}</p>
     </div>
 
     <div class="request-section">
@@ -85,7 +85,7 @@
 
     <div class="request-section">
       <h2 class="govuk-heading-m">What they think their role is</h2>
-      <p class="govuk-body">{{ request.sharedata.steps.role.value }}</p>
+      <p class="govuk-body">{{ request.sharedata.steps.role.value | capitalize }}</p>
     </div>
 
     <div class="request-section">
@@ -121,7 +121,7 @@
 
     <div class="request-section">
       <h2 class="govuk-heading-m">Data accessed by other organisations</h2>
-      <p class="govuk-body">{{ request.sharedata.steps['data-access'].value }}</p>
+      <p class="govuk-body">{{ request.sharedata.steps['data-access'].value | capitalize }}</p>
       <p class="govuk-body">Organisations:</p>
       <ul class="govuk-list govuk-list--bullet">
         {% for org in request.sharedata.steps['other-orgs'].value %}
@@ -148,18 +148,18 @@
     }) }}
   </div>
 </div>
-
-
 <div class="govuk-grid-row" style="margin-top: 3em;">
   <div class="govuk-grid-column-two-thirds">
-    <form method="post">
+    <form method="post" action="/manage-shares/received-requests/{{ request.requestId }}/review-request">
       {{ govukButton({
         text: "Continue",
-        name: "continueButton"
+        name: "continueButton",
+        value: "continue"
       }) }}
       {{ govukButton({
         text: "Return to summary",
         name: "returnButton",
+        value: "return",
         classes: "govuk-button--secondary"
       }) }}
     </form>

--- a/src/views/supplier/review-summary.njk
+++ b/src/views/supplier/review-summary.njk
@@ -8,14 +8,14 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: RR523</span>
-    <h1 class="govuk-heading-l">Department X is requesting access to access citizen-relationships data</h1>
+    <span class="govuk-caption-l">Request ID: {{ request.requestId }}</span>
+    <h1 class="govuk-heading-l">{{ request.requestingOrg }} is requesting access to {{ request.sharedata.assetTitle }} data</h1>
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Project aims</h2>
-    <p class="govuk-body">To assess claims and provide the correct level of support to vulnerable people based on their declared family relationships.</p>
+    <p class="govuk-body">{{ request.sharedata.steps["project-aims"].value.aims }}</p>
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Received</h2>
-    <p class="govuk-body">8 July 2023</p>
+    <p class="govuk-body">{{ request.received }}</p>
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Contact</h2>
-    <p class="govuk-body"><a href="#" class="govuk-link">data-team@department-x.gov.uk</a></p>
+    <p class="govuk-body"><a href="mailto:{{ request.sharedata.ownedBy }}" target="_blank" class="govuk-link">{{ request.sharedata.ownedBy }}</a></p>
     {{ govukWarningText({
       text: "Request not reviewed by Legal.",
       iconFallbackText: "Warning"
@@ -24,7 +24,7 @@
       text: "Data will travel outside UK.",
       iconFallbackText: "Warning"
     }) }}
-    <form action="/manage-shares/review-summary" method="POST" id="reviewSummaryForm">
+    <form method="POST" id="reviewSummaryForm">
       <div class="govuk-button-group">
         {{ govukButton({
             text: "Continue",
@@ -36,7 +36,7 @@
     </form>
     <h2 class="govuk-heading-m">More information</h2>
     {% set detailsContent %}
-    <p>You're about to review a data share request. You'll need to decide if it meets your requirements so you can draft a data sharing agreement with Department X.</p>
+    <p>You're about to review a data share request. You'll need to decide if it meets your requirements so you can draft a data sharing agreement with {{ request.requestingOrg }}</p>
     <p>When you've reviewed the request, you can choose to:</p>
     <ul>
       <li>Accept the data share request</li>

--- a/src/views/supplier/review-summary.njk
+++ b/src/views/supplier/review-summary.njk
@@ -16,14 +16,6 @@
     <p class="govuk-body">{{ request.received }}</p>
     <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Contact</h2>
     <p class="govuk-body"><a href="mailto:{{ request.sharedata.ownedBy }}" target="_blank" class="govuk-link">{{ request.sharedata.ownedBy }}</a></p>
-    {{ govukWarningText({
-      text: "Request not reviewed by Legal.",
-      iconFallbackText: "Warning"
-    }) }}
-    {{ govukWarningText({
-      text: "Data will travel outside UK.",
-      iconFallbackText: "Warning"
-    }) }}
     <form method="POST" id="reviewSummaryForm">
       <div class="govuk-button-group">
         {{ govukButton({


### PR DESCRIPTION
As a supplier we now see requests made to the specific organisation that the acquirer wants to request data from, as an acquirer I want to request data from `Department of work and Pension`, I have done so.

As a supplier when reviewing "Received requests", we now see requests made to us in this instance as a supplier `under the organisation`: `Department of Work and Pensions`
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/14d03a02-1712-41ea-9df4-06b5b87454c4)

We can see the `month`, in the dates have been formatted

As a supplier I click requestId 
I then see the request summary:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/3878c739-814f-44e0-a4e5-2c02007772d3)
I can see the data from the request.

I can Click continue:

In this pr, click `Accept data share request`:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/91167e21-5dcb-469c-a5a0-b2de76ebaa21)

hit the declaration `static page`

further on to the `Request accepted page`
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/c0f13d1a-8c94-4239-a8bf-227fd0aea8b3)

Currently this PR is without functionality to "sign off a ` received request` as `completed, accepted, rejected and or returned`

Video:
https://i.gyazo.com/7db29f97bc4230832bde5cc0c3d4266c.mp4