### PR TITLE
status changes regardless of its current state

### DIFF
--- a/src/helperFunctions/formHelper.ts
+++ b/src/helperFunctions/formHelper.ts
@@ -63,9 +63,7 @@ export const updateStepsStatus = (
 
   // If "Save and return" was clicked, set to "IN PROGRESS" if needed and return
   if (returnToStart) {
-    if (formdata.steps[currentStep].status !== "COMPLETED") {
-      formdata.steps[currentStep].status = "IN PROGRESS";
-    }
+    formdata.steps[currentStep].status = "IN PROGRESS";
     return;
   } else {
     // If "Save and Continue" was clicked, set this step to "COMPLETED"


### PR DESCRIPTION
## Problem statement: 
when on a step, answering and hitting `Save and continue` sets the status to `COMPLETE`, going back to the same step and hitting `Save and return` does not change the step `status` to `IN PROGRESS`.

## Solution:
We removed this: if `(formdata.steps[currentStep].status !== "COMPLETED") {` so we no longer do a check on the status, simply hitting save and return on a previously `COMPLETED` step will set the `status` to `IN PROGRESS`.