### PR TITLE
Display updated metadata

### DIFF
--- a/src/views/resource.njk
+++ b/src/views/resource.njk
@@ -186,7 +186,7 @@
         </tbody>
         </table>
     </div>
-    {% if resource.servesData or resource.accessService %}
+    {% if resource.servesDataset or resource.relatedAssets %}
     <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
         <div class="gem-c-contextual-sidebar">
             <div class="gem-c-related-navigation">
@@ -194,17 +194,25 @@
                     Related Data
                 </h2>
                 <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-ae81accd">
-                    {% if resource.servesData %}
+                    {% if resource.servesDataset %}
                     <ul class="gem-c-related-navigation__link-list">
-                        {% for data in resource.servesData %}
-                            <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="#">{{data}}</a></li>
+                        {% for data in resource.servesDataset %}
+                            {% if data.identifier %}
+                                <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/find/{{data.identifier}}">{{data.title}}</a></li>
+                            {% else %}
+                                <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="#">{{data}}</a></li>
+                            {% endif %}
                         {%endfor%}
                     </ul>
                     {% endif %}
-                    {% if resource.accessService %}
+                    {% if resource.relatedAssets %}
                     <ul class="gem-c-related-navigation__link-list">
-                        {% for data in resource.accessService %}
-                            <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="#">{{data}}</a></li>
+                        {% for data in resource.relatedAssets %}
+                            {% if data.identifier %}
+                                <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/find/{{data.identifier}}">{{data.title}}</a></li>
+                            {% else %}
+                                <li class="gem-c-related-navigation__link"><a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="#">{{data}}</a></li>
+                            {% endif %}
                         {%endfor%}
                     </ul>
                     {% endif %}


### PR DESCRIPTION
# Display updated metadata
This PR updates the frontend to use the updated metadata returned by the API in [this PR](https://github.com/co-cddo/data-marketplace-api/pull/24), (which Alasdair requested [here](https://tpximpact.slack.com/archives/C05F79AF7T3/p1694767000964429?thread_ts=1694766533.436699&cid=C05F79AF7T3))

If any related data assets are available in our database we now show a nicely-formatted link to the asset rather than a full URL.
E.g.
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/88ebf4fc-da4c-4e97-89c2-d52d44a516ec)
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/5aac6d09-18a2-4c03-89ba-cd1b87b74855)
