### PR TITLE
DMBM/843 - Request returned with comments

### DIFF
--- a/src/helperFunctions/formHelper.ts
+++ b/src/helperFunctions/formHelper.ts
@@ -769,7 +769,7 @@ function checkAnswer(formdata: FormData) {
       value: { html: dataTypeValue.join("") },
     };
 
-    if (formdata.status !== "ACCEPTED" && formdata.status !== "REJECTED") {
+    if (formdata.status !== "ACCEPTED" && formdata.status !== "REJECTED" && formdata.status !== "RETURNED") {
       rows[stepId].actions = {
         items: [
           {

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -102,8 +102,9 @@ router.get(
     );
     let pendingRows: ShareRequestTable = pendingRequests.map((r) => [
       {
-        html: `<a href="/acquirer/${r.sharedata.dataAsset
-          }/start">${r.requestId.substring(0, 8)}...</a>`,
+        html: `<a class="govuk-link" href="/manage-shares/created-requests/${
+          r.requestId
+        }/view-answers">${r.requestId.substring(0, 8)}...</a>`,
       },
       { text: r.assetTitle },
       { text: r.assetPublisher.title },
@@ -236,7 +237,7 @@ router.get(
   async (req: Request, res: Response) => {
     const requestId = req.params.requestId;
     const backLink =
-      req.headers.referer || `/manage-shares/created-requests/${requestId}`;
+      req.headers.referer || `/manage-shares/created-requests/`;
 
     try {
       const requestDetail = await axios.get(


### PR DESCRIPTION
This PR implements the acquirer journey of viewing a returned request with comments after making a share request. When an acquirer clicks on the Request ID of a returned request, they are taken to a page displaying comments made by the supplier as well as their original data share request answers in a static HTML format.
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/9f7e5635-03ad-4edb-aefb-d49ab89bb677)
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/edcc16f4-8133-4d6a-bef2-1868bad1c1c6)


I have again made use of the checkAnswer form, where if the form verifies that the request is RETURNED, it doesn't display the 'change' button on the static answers page. 

