### PR TITLE
DMBM-909: Permissions (and received-requests)

### DIFF
--- a/requests/requests.http.template
+++ b/requests/requests.http.template
@@ -29,7 +29,7 @@ PUT {{API}}/users/complete-profile
 Authorization: {{jwt}}
 
 {
-    "org": "department-for-work-pensions",
+    "org": "ofsted",
     "role": "lawyer"
 }
 
@@ -62,12 +62,12 @@ PUT {{API}}/manage-shares/received-requests/{{request_id}}/decision
 Authorization: {{jwt}}
 
 {
-    "status": "REJECTED",
+    "status": "RETURNED",
     "decisionNotes": "This is not Ok"
 }
 
 ### Add user permissions
-PUT {{API}}/users/b64c6e5a9861aa120c06caac1f2dfc3d/permissions
+PUT {{API}}/users/{{user}}/permissions
 x-api-key: {{ops-api-key}}
 
 {

--- a/requests/requests.http.template
+++ b/requests/requests.http.template
@@ -3,7 +3,6 @@
 @jwt = Bearer <copy from browser>
 @user = <first.last>@digital.cabinet-office.gov.uk
 
-
 ### Test login:
 GET {{API}}/login
 Authorization: {{jwt}}
@@ -22,7 +21,7 @@ PUT {{API}}/users/{{user}}/org
 x-api-key: {{ops-api-key}}
 
 {
-    "org": "ofsted"
+    "org": "department-for-work-pensions"
 }
 
 ### Let a user complete their profile (JWT):
@@ -63,14 +62,26 @@ PUT {{API}}/manage-shares/received-requests/{{request_id}}/decision
 Authorization: {{jwt}}
 
 {
-    "status": "RETURNED",
+    "status": "REJECTED",
     "decisionNotes": "This is not Ok"
 }
 
-### Change user permissions
-PUT {{API}}/users/{{user}}/permissions
+### Add user permissions
+PUT {{API}}/users/b64c6e5a9861aa120c06caac1f2dfc3d/permissions
 x-api-key: {{ops-api-key}}
 
-            {
-    "remove": ["MEMBER" , "PUBLISHER" , "SHARE_REVIEWER" , "ADMINISTRATOR"]
+{
+    "add": ["SHARE_REVIEWER"]
 }
+
+### Remove user permissions
+PUT {{API}}/users/b64c6e5a9861aa120c06caac1f2dfc3d/permissions
+x-api-key: {{ops-api-key}}
+
+{
+    "remove": ["SHARE_REVIEWER"]
+}
+
+### Check a user's permissions
+GET {{API}}/users/permission/organisation/department-for-work-pensions/VIEW_SHARE_REQUESTS
+Authorization: {{jwt}}

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import {
   JwtStrategy,
   modifyApplicationMiddleware,
 } from "./middleware/authMiddleware";
+import { apiUser } from "./middleware/apiMiddleware";
 
 export const app = express();
 // Set up security headers with Helmet
@@ -129,7 +130,7 @@ app.use("/profile", authenticateJWT, profileRoutes);
 app.use("/find", findRoutes);
 app.use("/share", authenticateJWT, shareRoutes);
 app.use("/acquirer", authenticateJWT, acquirerRoutes);
-app.use("/manage-shares", authenticateJWT, manageRoutes);
+app.use("/manage-shares", authenticateJWT, apiUser, manageRoutes);
 app.use("/cookie-settings", cookieRoutes);
 app.use("/learn", learnRoutes);
 app.use("/admin", adminRoutes);

--- a/src/middleware/ABACMiddleware.ts
+++ b/src/middleware/ABACMiddleware.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { NextFunction, Request, Response } from "express";
+
+export const createAbacMiddleware =
+  (target_type: string, action: string, errorMessage: string) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    let target_id;
+    if (target_type === "organisation") {
+      target_id = req.user.organisation?.slug || "";
+    } else {
+      // The only target_types are organisation or asset.
+      // If it's asset, get the ID from the path params
+      target_id = req.params.resourceID;
+    }
+    if (!target_id) {
+      return res.render("error.njk", {
+        messageTitle: "Permissions error",
+        messageBody: `ID: ${target_id} for target_type: ${target_type} is not valid.`,
+      });
+    }
+
+    try {
+      const abacResponse = await axios.get(
+        `${process.env.API_ENDPOINT}/users/permission/${target_type}/${target_id}/${action}`,
+        {
+          headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
+        },
+      );
+      const isAllowed: boolean = abacResponse.data;
+      if (!isAllowed) {
+        return res.render("error.njk", {
+          messageTitle: "Permissions error",
+          messageBody: errorMessage,
+        });
+      }
+      next();
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.error(
+          `API ERROR - ${error.response?.status}: ${error.response?.statusText}`,
+        );
+        console.error(error.response?.data.detail);
+      } else {
+        console.error(error);
+      }
+      next(error);
+    }
+  };

--- a/src/views/supplier/received-requests.njk
+++ b/src/views/supplier/received-requests.njk
@@ -3,26 +3,28 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Manage data share requests</span>
-    <h1 class="govuk-heading-xl">Received requests</h1>
-  </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <span class="govuk-caption-l">Manage data share requests</span>
+            <h1 class="govuk-heading-xl">Received requests</h1>
+        </div>
 
-  <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items">
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list">
-            <li><a href="{{assetPath}}/manage-shares/created-requests" class="govuk-link">View created requests</a></li>
-          </ul>
-        </nav>
-    </aside>
-  </div>
-</div>
+        <div class="govuk-grid-column-one-third">
+            <aside class="app-related-items">
+                <nav role="navigation" aria-labelledby="subsection-title">
+                    <ul class="govuk-list">
+                        <li>
+                            <a href="{{assetPath}}/manage-shares/created-requests" class="govuk-link">View created requests</a>
+                        </li>
+                    </ul>
+                </nav>
+            </aside>
+        </div>
+    </div>
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        {{ govukTable({
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ govukTable({
             caption: "Current requests",
             captionClasses: "govuk-table__caption--l",
             head: [
@@ -45,14 +47,14 @@
                 text: "Status"
             }
             ],
-            rows: receivedTableRows
+            rows: currentRows
         }) }}
-  </div>
-</div>
+        </div>
+    </div>
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-    {{ govukTable({
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ govukTable({
         caption: "Completed  requests",
         captionClasses: "govuk-table__caption--l",
         head: [
@@ -75,49 +77,8 @@
             text: "Decision"
         }
         ],
-        rows: [
-        [
-            {
-                html: '<a href="/manage-shares/request-accepted" class="govuk-link">RR147 - View</a>'
-            },
-            {
-            text: "Department for Education"
-            },
-            {
-            text: "Inline-core_reporting-and-location"
-            },
-            {
-            text: "18 Apr 2023"
-            },
-            {
-            text: "2 May 2023"
-            },
-            {
-            text: "Accepted"
-            }
-        ],
-        [
-            {
-                html: '<a href="/manage-shares/request-rejected" class="govuk-link">RR109 - View</a>'
-            },
-            {
-            text: "Department for Education"
-            },
-            {
-            text: "Input-switch_slice3"
-            },
-            {
-            text: "2 Apr 2023"
-            },
-            {
-            text: "2 May 2023"
-            },
-            {
-            text: "Rejected"
-            }
-        ]
-    ]}) }}
-  </div>
-</div>
-  
-{% endblock %} 
+        rows: completedRows}) }}
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
# Permissions
This PR adds a new function which creates a middleware for calling the ABAC API endpoint.
The ABAC API endpoint needs to be called like this:
`GET {API}/users/permission/{target_type}/{target_id}/{action}`
where `target_type` is `asset` or `organisation`, `target_id` is the asset ID or organisation slug, and `action` is `READ`, `EDIT` or `REQUEST` for `target_type=asset`, or `CREATE_ASSET`, `VIEW_SHARE_REQUESTS` or `REVIEW_SHARE_REQUESTS` for `target_type=organisation`.

The `createAbacMiddleware` function takes `target_type` and `action`, determines `target_id` based on the logged in User or request path, and returns a function that can be used as middleware.

The middleware then just calls the ABAC API to check whether the user has the right permissions.
If the user does not have the attributes required to perform the action they are redirected to an error page which displays "Permissions error".

To test this locally you'll need to use the `Add user permissions` example request to add/remove `SHARE_REVIEWER` permissions from your user.

I've added the new middleware to all received-requests routes.
It would definitely be tidier to move the routes handling created-requests into a different router than the received-requests, so that the ABAC middleware could be used by the entire router, but I didn't want to tackle that here.

# Received requests
This PR also adds some changes to the received-requests route, to remove the dummy data and filter the current & completed requests into the correct sections.

There is currently a bug in the API - the `decisionDate` is not provided, so it can't be displayed in the Completed Requests table. The bug is fixed by [this PR](https://github.com/co-cddo/data-marketplace-api/pull/27).