### PR TITLE
fixes odd bug persisting

### DIFF
--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -2,7 +2,8 @@ name: Lint & Test
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - "*"
 
 jobs:
   test-and-lint:

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -110,7 +110,7 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     formdata.stepHistory = [];
   }
 
-  //handle form errors
+  // handle form errors
   if (req.session.formValuesValidationError) {
     stepData.value = extractFormData(
       stepData,
@@ -262,6 +262,9 @@ router.post(
     if (req.body.continueButton && nextStep) {
       redirectURL = `/acquirer/${resourceID}/${nextStep}`;
     }
+
+    //reset errors at this point as API doesnt need them and validation has happened
+    formdata.steps[formStep].errorMessage = "";
 
     // Send the formdata to the backend if logged in
     if (req.isAuthenticated()) {


### PR DESCRIPTION
After validation was run, the errorMessage wasnt emptied. This was trying to pass an object to the API which failed.
This PR's empties errorMessages for steps that pass validation