### PR TITLE
DMBM- 920 - View full returned request with ability to resubmit + view notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-marketplace",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "imagename": "dm-frontend",
   "description": "",
   "main": "index.js",

--- a/src/helperFunctions/formHelper.ts
+++ b/src/helperFunctions/formHelper.ts
@@ -769,11 +769,7 @@ function checkAnswer(formdata: FormData) {
       value: { html: dataTypeValue.join("") },
     };
 
-    if (
-      formdata.status !== "ACCEPTED" &&
-      formdata.status !== "REJECTED" &&
-      formdata.status !== "RETURNED"
-    ) {
+    if (formdata.status !== "ACCEPTED" && formdata.status !== "REJECTED") {
       rows[stepId].actions = {
         items: [
           {

--- a/src/helperFunctions/stringHelpers.ts
+++ b/src/helperFunctions/stringHelpers.ts
@@ -1,3 +1,18 @@
 export const capitalise = (s: string) => {
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 };
+
+export const formatDate = (dateString: string | null): string => {
+  if (!dateString) {
+    return "";
+  }
+  if (dateString === "UNREQUESTED") {
+    return "Unrequested";
+  }
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  return new Date(dateString).toLocaleDateString("en-GB", options);
+};

--- a/src/middleware/apiMiddleware.ts
+++ b/src/middleware/apiMiddleware.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { NextFunction, Request, Response } from "express";
 import { ApiUser } from "../models/apiUser";
 import { ShareRequestResponse } from "../types/express";
+import { formatDate } from "../helperFunctions/stringHelpers";
 
 const API = `${process.env.API_ENDPOINT}`;
 
@@ -54,6 +55,11 @@ export const shareRequestDetailMiddleware = async (
     );
     const shareRequestDetail =
       shareRequestDetailResponse.data as ShareRequestResponse;
+    shareRequestDetail.received = formatDate(shareRequestDetail.received);
+    shareRequestDetail.neededBy = formatDate(shareRequestDetail.neededBy);
+    shareRequestDetail.decisionDate = formatDate(
+      shareRequestDetail.decisionDate,
+    );
     req.shareRequest = shareRequestDetail;
     next();
   } catch (error) {

--- a/src/middleware/validateFormMiddleware.ts
+++ b/src/middleware/validateFormMiddleware.ts
@@ -258,14 +258,16 @@ function getProtectionReviewValidation() {
 function getDeliveryValidation() {
   return [
     body("delivery")
-    .exists()
-    .withMessage("Select Through secure third-party software, Physical delivery or Something else"),
-    
+      .exists()
+      .withMessage(
+        "Select Through secure third-party software, Physical delivery or Something else",
+      ),
+
     body("something-else")
-    .if(body("delivery").contains('something'))
-    .notEmpty()
-    .withMessage("How would you like to receive the data")
-    .escape(),
+      .if(body("delivery").contains("something"))
+      .notEmpty()
+      .withMessage("How would you like to receive the data")
+      .escape(),
   ];
 }
 

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -83,7 +83,7 @@ router.get(
             ? `<a class="govuk-link" href="/acquirer/${
                 r.sharedata.dataAsset
               }/check">${r.requestId.substring(0, 8)}...</a>`
-            : `<a href="/acquirer/${
+            : `<a class="govuk-link" href="/acquirer/${
                 r.sharedata.dataAsset
               }/start">${r.requestId.substring(0, 8)}...</a>`,
       },
@@ -132,7 +132,7 @@ router.get(
     );
     let completedRows: ShareRequestTable = completedRequests.map((r) => [
       {
-        html: `<a href="/manage-shares/created-requests/${
+        html: `<a class="govuk-link" href="/manage-shares/created-requests/${
           r.requestId
         }">${r.requestId.substring(0, 8)}...</a>`,
       },
@@ -246,10 +246,10 @@ router.get(
       {
         html:
           r.status === "RETURNED"
-            ? `<a href="/manage-shares/received-requests/${
+            ? `<a class="govuk-link" href="/manage-shares/received-requests/${
                 r.requestId
               }/outcome">${r.requestId.substring(0, 8)}...</a>`
-            : `<a href="/manage-shares/received-requests/${
+            : `<a class="govuk-link" href="/manage-shares/received-requests/${
                 r.requestId
               }">${r.requestId.substring(0, 8)}...</a>`,
       },
@@ -274,7 +274,7 @@ router.get(
     );
     let completedRows: ShareRequestTable = completedRequests.map((r) => [
       {
-        html: `<a href="/manage-shares/received-requests/${
+        html: `<a class="govuk-link" href="/manage-shares/received-requests/${
           r.requestId
         }/outcome">${r.requestId.substring(0, 8)}...</a>`,
       },

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -116,14 +116,7 @@ router.get(
     );
     let pendingRows: ShareRequestTable = pendingRequests.map((r) => [
       {
-        html:
-          r.status === "RETURNED"
-            ? `<a class="govuk-link" href="/manage-shares/created-requests/${
-                r.requestId
-              }/view-answers">${r.requestId.substring(0, 8)}...</a>`
-            : `<a href="/acquirer/${
-                r.sharedata.dataAsset
-              }/start">${r.requestId.substring(0, 8)}...</a>`,
+        html: `<a href="/acquirer/${r.sharedata.dataAsset}/check">${r.requestId.substring(0, 8)}...</a>`,
       },
       { text: r.assetTitle },
       { text: r.assetPublisher.title },

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -230,7 +230,7 @@ declare module "express-serve-static-core" {
 
 declare module "express-session" {
   interface SessionData {
-    acquirerForms?: Record<string, FormData>;
+    acquirerForms: Record<string, FormData>;
     backLink: string;
     formErrors: { [key: string]: { text: string } };
     decision: { status: string; notes: string };

--- a/src/views/acquirer/check.njk
+++ b/src/views/acquirer/check.njk
@@ -1,10 +1,26 @@
 {% extends "page.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set returnedNotesHtml %}
+<div>
+  <p class="govuk-notification-banner__heading">
+    {{returnedNotesTitle}}
+  </p>
+  <p>{{returnedNotes}}</p>
+</div>
+{% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
+      {% if returnedNotes %}
+        {{ govukNotificationBanner({
+          titleText: "Comments",
+          html: returnedNotesHtml
+        }) }}
+      {% endif %}
       <span class="govuk-caption-l">Request ID: {{requestId}}</span>
       <h1 class="govuk-heading-xl">Check your answers before sending your request</h1>
     </div>

--- a/src/views/acquirer/confirmation.njk
+++ b/src/views/acquirer/confirmation.njk
@@ -11,7 +11,7 @@
       }) }}
     <p class="govuk-body">We have sent you a confirmation email.</p>
     <h2 class="govuk-heading-m">What happens next</h2>
-    <p class="govuk-body">{{contactPoint.name}} will review your requests.</p>
+    <p class="govuk-body">The data supplier will review your request.</p>
     <p class="govuk-body">It can take up to X working days for them to reply. You can track the status of your request when you <a href="/manage-shares/" class="govuk-link">manage data share requests</a>.</p>
     <p class="govuk-body">If you have any problems, you can also contact the data asset owner, <a class="govuk-link" href="mailto:{{contactPoint.email}}">{{contactPoint.email}}.</a></p>
 

--- a/src/views/acquirer/created-request-outcome.njk
+++ b/src/views/acquirer/created-request-outcome.njk
@@ -1,7 +1,7 @@
 {% extends "page.njk" %}
 
 {% if request.status === "ACCEPTED" %}
-  {% set nextSteps = "Your department's contact email has been shared with the " + request.assetPublisher.title + " so they can begin working with you on the data share arrangement. You are able to contact them at " + request.publisherContactEmail + "."  %}
+  {% set nextSteps = "Your department's contact email has been shared with the " + request.assetPublisher.title + " so they can begin working with you on the data share arrangement. You are able to contact them at " + request.publisherContactEmail + "." %}
 {% elif request.status === "REJECTED" %}
   {% set nextSteps = "This request has been rejected. Consider the feedback before making further data share requests." %}
 {% else %}
@@ -9,46 +9,45 @@
 {% endif %}
 
 {% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: {{request.requestId}}</span>
-    <h1 class="govuk-heading-xl">
-      {{ request.status | capitalize }} request
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{request.requestId}}</span>
+      <h1 class="govuk-heading-xl">
+        {{ request.status | capitalize }} request
     </h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Decision made</h2>
-    <p class="govuk-body">{{ request.decisionDate }}</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Feedback provided</h2>
-    <p class="govuk-body">{{ request.decisionNotes }}</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
-    <p class="govuk-body">{{ nextSteps }}</p>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Data owner</h2>
-    <p class="govuk-body">{{ request.assetPublisher.title }}</p>
-
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Dataset</h2>
-    <p class="govuk-body">{{ request.assetTitle }}</p>
-
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Needed by</h2>
-    <p class="govuk-body">{{ request.neededBy }}</p>
+    </div>
   </div>
 
   <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-button-group govuk-!-static-margin-top-9">
-      <a href="{{assetPath}}/manage-shares/created-requests/{{request.sharedata.requestId}}/view-answers" class="govuk-button govuk-button--secondary">View full request</a>
-      <a href="{{assetPath}}/manage-shares/created-requests" class="govuk-link">Return to created requests</a>
-    </div>
-  </div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Decision made</h2>
+      <p class="govuk-body">{{ request.decisionDate }}</p>
 
-{% endblock %}
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Feedback provided</h2>
+      <p class="govuk-body">{{ request.decisionNotes if request.decisionNotes else "No feeback provided." }}</p>
+
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
+      <p class="govuk-body">{{ nextSteps }}</p>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Data owner</h2>
+      <p class="govuk-body">{{ request.assetPublisher.title }}</p>
+
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Dataset</h2>
+      <p class="govuk-body">{{ request.assetTitle }}</p>
+
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Needed by</h2>
+      <p class="govuk-body">{{ request.neededBy }}</p>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-button-group govuk-!-static-margin-top-9">
+          <a href="{{assetPath}}/manage-shares/created-requests/{{request.sharedata.requestId}}/view-answers" class="govuk-button govuk-button--secondary">View full request</a>
+          <a href="{{assetPath}}/manage-shares/created-requests" class="govuk-link">Return to created requests</a>
+        </div>
+      </div>
+    </div>
+
+  {% endblock %}

--- a/src/views/acquirer/created-request-outcome.njk
+++ b/src/views/acquirer/created-request-outcome.njk
@@ -1,7 +1,7 @@
 {% extends "page.njk" %}
 
 {% if request.status === "ACCEPTED" %}
-  {% set nextSteps = "Your department's contact email has been shared with the " + request.assetPublisher.title + " so they can begin working with you on the data share arrangement. You are able to contact them at data-management@test.co.uk" %}
+  {% set nextSteps = "Your department's contact email has been shared with the " + request.assetPublisher.title + " so they can begin working with you on the data share arrangement. You are able to contact them at " + request.publisherContactEmail + "."  %}
 {% elif request.status === "REJECTED" %}
   {% set nextSteps = "This request has been rejected. Consider the feedback before making further data share requests." %}
 {% else %}

--- a/src/views/acquirer/created-request-view-full-request.njk
+++ b/src/views/acquirer/created-request-view-full-request.njk
@@ -16,10 +16,11 @@
           <p class="govuk-notification-banner__heading">
             From {{request.assetPublisher.title}}
           </p>
-          <p>{{request.decisionNotes}}</p>
+          <p>{{request.decisionNotes if request.decisionNotes else "No feedback provided."}}</p>
         </div>
       </div>
-      <span class="govuk-caption-l">Request ID: {{request.requestId}}</span> </div>
+      <span class="govuk-caption-l">Request ID: {{request.requestId}}</span>
+    </div>
     <div class="govuk-grid-column-full" id="checkYourAnswers">
       {% for section in sharedata %}
         <h2 class="govuk-heading-m check-heading">{{section.name}}</h2>

--- a/src/views/partials/receivedRequestReview.njk
+++ b/src/views/partials/receivedRequestReview.njk
@@ -56,10 +56,12 @@
     {% endif %}
 </div>
 
+{% if request.sharedata.steps['data-subjects'].value %}
 <div class="request-section">
     <h2 class="govuk-heading-m">Data subjects</h2>
     <p class="govuk-body">{{ request.sharedata.steps['data-subjects'].value }}</p>
 </div>
+{% endif %}
 
 <div class="request-section">
     <h2 class="govuk-heading-m">Aim of project</h2>
@@ -103,10 +105,12 @@
     </ul>
 </div>
 
+{% if request.sharedata.steps.role.value %}
 <div class="request-section">
     <h2 class="govuk-heading-m">What they think their role is</h2>
     <p class="govuk-body">{{ replacements['role'].data[request.sharedata.steps.role.value]}}</p>
 </div>
+{% endif %}
 
 <div class="request-section">
     <h2 class="govuk-heading-m">Data they want</h2>

--- a/src/views/supplier/received-request-outcome.njk
+++ b/src/views/supplier/received-request-outcome.njk
@@ -10,51 +10,51 @@
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">Request ID: {{request.requestId}}</span>
-    <h1 class="govuk-heading-xl">
-      {{ request.status | capitalize }} request
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Request ID: {{request.requestId}}</span>
+      <h1 class="govuk-heading-xl">
+        {{ request.status | capitalize }} request
     </h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Decision made</h2>
-    <p class="govuk-body">{{ request.decisionDate }}</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Feedback provided</h2>
-    <p class="govuk-body">{{ request.decisionNotes }}</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Notes</h2>
-    <p class="govuk-body">{{ request.reviewNotes if request.reviewNotes else "No notes provided." }}</p>
-
-    <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
-    <p class="govuk-body">{{ nextSteps }}</p>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Requested by</h2>
-    <p class="govuk-body">{{ request.requestingOrg }}</p>
-
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Dataset</h2>
-    <p class="govuk-body">{{ request.assetTitle }}</p>
-
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Received</h2>
-    <p class="govuk-body">{{ request.received }}</p>
-
-    <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Needed by</h2>
-    <p class="govuk-body">{{ request.neededBy }}</p>
+    </div>
   </div>
 
   <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-button-group govuk-!-static-margin-top-9">
-      <a href="{{assetPath}}/manage-shares/received-requests/{{request.requestId}}/view-answers" class="govuk-button govuk-button--secondary">View full request</a>
-      <a href="{{assetPath}}/manage-shares/received-requests" class="govuk-link">Return to received requests</a>
-    </div>
-  </div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Decision made</h2>
+      <p class="govuk-body">{{ request.decisionDate }}</p>
 
-{% endblock %}
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Feedback provided</h2>
+      <p class="govuk-body">{{ request.decisionNotes if request.decisionNotes else "No feedback provided." }}</p>
+
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">Notes</h2>
+      <p class="govuk-body">{{ request.reviewNotes if request.reviewNotes else "No notes provided." }}</p>
+
+      <h2 class="govuk-heading-m govuk-!-static-margin-bottom-1">What happens next</h2>
+      <p class="govuk-body">{{ nextSteps }}</p>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Requested by</h2>
+      <p class="govuk-body">{{ request.requestingOrg }}</p>
+
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Dataset</h2>
+      <p class="govuk-body">{{ request.assetTitle }}</p>
+
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Received</h2>
+      <p class="govuk-body">{{ request.received }}</p>
+
+      <h2 class="govuk-heading-s govuk-!-static-margin-bottom-1">Needed by</h2>
+      <p class="govuk-body">{{ request.neededBy }}</p>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-button-group govuk-!-static-margin-top-9">
+          <a href="{{assetPath}}/manage-shares/received-requests/{{request.requestId}}/view-answers" class="govuk-button govuk-button--secondary">View full request</a>
+          <a href="{{assetPath}}/manage-shares/received-requests" class="govuk-link">Return to received requests</a>
+        </div>
+      </div>
+    </div>
+
+  {% endblock %}


### PR DESCRIPTION
This PR alters the current implementation of displaying an acquirer's returned full request statically and instead directs the user to the `/check` page with the ability to change their answers and resubmit. The page also displays any decision notes given by the asset publisher who returned the request.

![image](https://github.com/co-cddo/data-marketplace/assets/107464669/5b2d1658-dfb5-43db-92fb-704887eb5d5e)
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/715bc242-1de6-4fc4-8bcf-8920c8a04aa6)
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/0501c137-8414-409f-b7a3-bddb8ea82361)

(Thanks @kjoshi for your help!!)