### PR TITLE
DMBM-937 - Remove markdown from search results' asset descriptions/summaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digital-marketplace",
-  "version": "0.0.22",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digital-marketplace",
-      "version": "0.0.22",
+      "version": "0.0.24",
       "license": "ISC",
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.2",
@@ -29,6 +29,7 @@
         "passport-jwt": "^4.0.1",
         "passport-oauth2": "^1.7.0",
         "querystring": "^0.2.1",
+        "remove-markdown": "^0.5.0",
         "sass": "^1.63.6"
       },
       "devDependencies": {
@@ -45,6 +46,7 @@
         "@types/nunjucks": "^3.2.3",
         "@types/passport": "^1.0.12",
         "@types/passport-oauth2": "^1.4.12",
+        "@types/remove-markdown": "^0.3.1",
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -3148,6 +3150,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "node_modules/@types/remove-markdown": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/remove-markdown/-/remove-markdown-0.3.1.tgz",
+      "integrity": "sha512-JpJNEJEsmmltyL2LdE8KRjJ0L2ad5vgLibqNj85clohT9AyTrfN6jvHxStPshDkmtcL/ShFu0p2tbY7DBS1mqQ==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -9637,6 +9645,11 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/remove-markdown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.0.tgz",
+      "integrity": "sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "passport-jwt": "^4.0.1",
     "passport-oauth2": "^1.7.0",
     "querystring": "^0.2.1",
+    "remove-markdown": "^0.5.0",
     "sass": "^1.63.6"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/nunjucks": "^3.2.3",
     "@types/passport": "^1.0.12",
     "@types/passport-oauth2": "^1.4.12",
+    "@types/remove-markdown": "^0.3.1",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/routes/findRoutes.ts
+++ b/src/routes/findRoutes.ts
@@ -6,6 +6,7 @@ import {
   fetchOrganisations,
 } from "../services/findService";
 import { themes } from "../mockData/themes";
+import removeMd from 'remove-markdown';
 
 router.get("/", async (req: Request, res: Response, next: NextFunction) => {
   const backLink = req.session.backLink || "/";
@@ -31,6 +32,16 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
       organisationFilters,
       themeFilters,
     );
+
+    // Strip Markdown from each resource's summary and description
+    resources.forEach(resource => {
+      if (resource.summary) {
+        resource.summary = removeMd(resource.summary);
+      }
+      if (resource.description) {
+        resource.description = removeMd(resource.description);
+      }
+    });
     const organisations = await fetchOrganisations();
     const themesList = themes;
     const filterOptions = [


### PR DESCRIPTION
This PR addresses the issues caused by markdown being displayed in the asset description/summary on the search results page (shown below).
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/1e1c50cc-97d9-441e-b316-e4848c1b8649)

I initially tried rendering the markdown but some of the markdown includes titles, which does not look good as a truncated description (shown below).
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/f2f34fdf-e217-41e5-b03a-71af34a20bf5)


Instead, I have installed the [remove-markdown](https://www.npmjs.com/package/remove-markdown) package + corresponding [@types](https://www.npmjs.com/package/@types/remove-markdown) package and have called the `removeMd()` function on each resource's summary and description if there is one (shown below)
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/9e4d58fc-7384-4d36-bfcf-7e00aff806ff)
