### PR TITLE
BUG - Add width styling to error pages

### DIFF
--- a/src/views/error.njk
+++ b/src/views/error.njk
@@ -3,6 +3,10 @@
 {% block pageTitle %}{{messageTitle}} - Data Marketplace - GOV.UK{% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-l govuk-!-font-weight-bold">{{messageTitle}}</h1>
-  <p class="govuk-body">{{messageBody}}</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l govuk-!-font-weight-bold">{{messageTitle}}</h1>
+      <p class="govuk-body">{{messageBody}}</p>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Minor PR adding the `two-thirds` width limit to the error pages.
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/a58ff5c1-febf-412a-9612-5c6630c05353)
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/31af5829-871a-4c6a-97a1-3c76ff03bfdc)
