### PR TITLE
Dmbm 951/removal of back link and nav buttons for confirmation pages

### DIFF
--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -320,10 +320,6 @@ router.post(
       }
     }
 
-    if (req.body.continueButton && formStep === "confirmation") {
-      return res.redirect(`/manage-shares/created-requests`);
-    }
-
     updateStepsStatus(
       formStep,
       stepData.value,

--- a/src/views/acquirer/confirmation.njk
+++ b/src/views/acquirer/confirmation.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set noBackLink = true %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/src/views/acquirer/confirmation.njk
+++ b/src/views/acquirer/confirmation.njk
@@ -16,16 +16,6 @@
     <p class="govuk-body">The data supplier will review your request.</p>
     <p class="govuk-body">It can take up to X working days for them to reply. You can track the status of your request when you <a href="/manage-shares/" class="govuk-link">manage data share requests</a>.</p>
     <p class="govuk-body">If you have any problems, you can also contact the data asset owner, <a class="govuk-link" href="mailto:{{contactPoint.email}}">{{contactPoint.email}}.</a></p>
-
-    <form method="POST" id="declarationForm">
-      <div class="govuk-button-group">
-        {{ govukButton({
-          text: "Return to manage data share requests",
-          name: "continueButton",
-          value: "continue"
-        }) }}
-      </div>
-    </form>
     </div>
   </div>
 {% endblock %}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -33,18 +33,20 @@
     </div>
 {% else %}
   <div class="govuk-width-container">
-    {% include "partials/phaseBanner.njk" %}
-    {% if pageHistory.length >= 2 %}
-      {% if '?' in pageHistory[pageHistory.length - 2] %}
-        {% set separator = '&' %}
+    {% if not noBackLink %}
+      {% include "partials/phaseBanner.njk" %}
+      {% if pageHistory.length >= 2 %}
+        {% if '?' in pageHistory[pageHistory.length - 2] %}
+          {% set separator = '&' %}
+        {% else %}
+          {% set separator = '?' %}
+        {% endif %}
+        <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[pageHistory.length - 2] }}{{ separator }}fromBack=true">Back</a>
+      {% elif pageHistory.length == 1 %}
+        <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[0] }}?fromBack=true">Back</a>
       {% else %}
-        {% set separator = '?' %}
+        <a id="history-back-link" class="govuk-back-link" href="/?fromBack=true">Back</a>
       {% endif %}
-      <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[pageHistory.length - 2] }}{{ separator }}fromBack=true">Back</a>
-    {% elif pageHistory.length == 1 %}
-      <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[0] }}?fromBack=true">Back</a>
-    {% else %}
-      <a id="history-back-link" class="govuk-back-link" href="/?fromBack=true">Back</a>
     {% endif %}
   </div>
 {% endif %}

--- a/src/views/supplier/accept-request.njk
+++ b/src/views/supplier/accept-request.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% set noBackLink = true %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/src/views/supplier/reject-request.njk
+++ b/src/views/supplier/reject-request.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% set noBackLink = true %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/src/views/supplier/return-request.njk
+++ b/src/views/supplier/return-request.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% set noBackLink = true %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
In this PR we can now choose which page shows the backLink button. On the frontend, we can now add `{% set noBackLink = true %}` to specific pages (partials) which will render the .njk page with noBackLink.

See example "decision" page:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/3ceedd01-6625-4477-9037-15632973fca5)

See example "confirmation" page:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/e6c97205-2526-4b15-a8ad-71aca5aee629)
Also note that the Continue button has been removed from the page.