### PR TITLE
DMBM/954 - search bar 'x' button

### DIFF
--- a/public/javascripts/searchBar.js
+++ b/public/javascripts/searchBar.js
@@ -1,0 +1,13 @@
+function clearSearchResults() {
+  document.addEventListener('DOMContentLoaded', function() {
+  const searchInput = document.getElementById('search');
+  const searchForm = document.getElementById('searchForm');
+
+  searchInput.addEventListener('input', function() {
+      if (!this.value.trim()) {
+          searchForm.submit();
+      }
+  });
+});
+}
+clearSearchResults();

--- a/src/routes/findRoutes.ts
+++ b/src/routes/findRoutes.ts
@@ -6,12 +6,18 @@ import {
   fetchOrganisations,
 } from "../services/findService";
 import { themes } from "../mockData/themes";
-import removeMd from 'remove-markdown';
+import removeMd from "remove-markdown";
 
 router.get("/", async (req: Request, res: Response, next: NextFunction) => {
   const backLink = req.session.backLink || "/";
   req.session.backLink = req.originalUrl;
-  const query: string | undefined = (req.query.q as string)?.toLowerCase();
+  // Extract and sanitize the search query:
+  // - Trim any whitespace from the beginning and end.
+  // - Convert the query to lowercase for consistent processing.
+  // If the result is an empty string (or only contained whitespace), set it to undefined.
+  const rawQuery: string | undefined = req.query.q as string;
+  const query = rawQuery?.trim().toLowerCase() || undefined;
+
   let organisationFilters: string[] | undefined = req.query
     .organisationFilters as string[] | undefined;
   let themeFilters: string[] | undefined = req.query.themeFilters as
@@ -33,12 +39,13 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
       themeFilters,
     );
 
-
-    resources.forEach(resource => {
+    resources.forEach((resource) => {
       if (resource.mediaType) {
-        resource.mediaType = resource.mediaType.map(type => type === 'OASIS' ? 'ODS' : type);
+        resource.mediaType = resource.mediaType.map((type) =>
+          type === "OASIS" ? "ODS" : type,
+        );
       }
-    // Strip Markdown from each resource's summary and description
+      // Strip Markdown from each resource's summary and description
       if (resource.summary) {
         resource.summary = removeMd(resource.summary);
       }
@@ -139,9 +146,9 @@ router.get("/:resourceID", async (req: Request, res: Response) => {
   const resource = await fetchResourceById(resourceID);
 
   if (resource.distributions) {
-    resource.distributions.forEach(distribution => {
-      if (distribution.mediaType === 'OASIS') {
-        distribution.mediaType = 'ODS';
+    resource.distributions.forEach((distribution) => {
+      if (distribution.mediaType === "OASIS") {
+        distribution.mediaType = "ODS";
       }
     });
   }

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -57,6 +57,7 @@
     <script src="{{ assetPath }}/javascripts/accordionExpander.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/removeFilter.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/backLink.js" type="text/javascript"></script>
+    <script src="{{ assetPath }}/javascripts/searchBar.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/cookies.js" defer></script>
     <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}


### PR DESCRIPTION
This PR enables the user to click the little ‘x’ on the search bar component and revert the page back to its original state (search results without search term), whilst maintaining any filter parameters. This is implemented with custom JS that listens for any value in the search input and if there is none, to submit the search form again. This is a bit of a work around and I have done this approach because we cannot directly interact with the little 'x' button that appears with the search bar as that is part of the GOV design system components. The user has to click away from the search bar once the 'x' is clicked, but this behaviour also occurs on the [GOV.UK website](https://www.gov.uk/search/all?keywords=test&order=relevance)'s search bar too. 
