### PR TITLE
Bugfix/acquirer form status

### DIFF
--- a/__tests__/form.test.ts
+++ b/__tests__/form.test.ts
@@ -28,7 +28,6 @@ const mockFormData: FormData = {
       errorMessage: ""
     },
   },
-  stepHistory: [],
 };
 
 describe("updateStepsStatus function", () => {

--- a/src/models/shareRequestTemplate.json
+++ b/src/models/shareRequestTemplate.json
@@ -3,7 +3,7 @@
   "dataAsset": "",
   "assetTitle": "",
   "ownedBy": "",
-  "status": "IN PROGRESS",
+  "status": "NOT STARTED",
   "completedSections": 0,
   "overviewSections": {
     "purpose": {

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -185,7 +185,6 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   });
 });
 
-
 router.post(
   "/:resourceID/:step",
   validateFormMiddleware,
@@ -206,11 +205,11 @@ router.post(
 
     stepData.value = extractFormData(stepData, req.body) || "";
 
-    if (formStep === 'benefits') {
-      const benefitsData = stepData.value
+    if (formStep === "benefits") {
+      const benefitsData = stepData.value;
       for (const value of Object.values(benefitsData)) {
         if (!value.checked) {
-          value.explanation = '';
+          value.explanation = "";
         }
       }
     }
@@ -282,7 +281,6 @@ router.post(
     if (req.body.continueButton && formStep === "declaration") {
       formdata.status = "AWAITING REVIEW";
     }
-
 
     if (req.body.continueButton && formStep === "confirmation") {
       return res.redirect(`/manage-shares/created-requests`);

--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -41,6 +41,8 @@ const generateFormTemplate = (
   return template;
 };
 
+const URL = `${process.env.API_ENDPOINT}/sharedata`;
+
 router.get("/:resourceID/start", async (req: Request, res: Response) => {
   const resourceID = req.params.resourceID;
   const backLink = req.headers.referer || `/share/${resourceID}/acquirer`;
@@ -64,6 +66,22 @@ router.get("/:resourceID/start", async (req: Request, res: Response) => {
     req.session.acquirerForms[resourceID] =
       req.session.acquirerForms?.[resourceID] ||
       generateFormTemplate(req, resourceID, assetTitle, contactPoint);
+
+    try {
+      await axios.put(
+        URL,
+        { sharedata: req.session.acquirerForms[resourceID] },
+        { headers: { Authorization: `Bearer ${req.cookies.jwtToken}` } },
+      );
+    } catch (error: unknown) {
+      console.error("Error sending formdata to backend");
+      if (axios.isAxiosError(error)) {
+        console.error(error.response?.data.detail);
+      } else {
+        console.error(error);
+      }
+    }
+
     res.render("../views/acquirer/start.njk", {
       route: req.params.page,
       heading: "Acquirer Start",
@@ -88,23 +106,6 @@ router.get("/:resourceID/check", async (req: Request, res: Response) => {
 
   const formdata = req.session.acquirerForms[resourceID];
 
-  if (!formdata.stepHistory) {
-    formdata.stepHistory = [];
-  }
-
-  if (req.query.action === "back") {
-    formdata.stepHistory.pop();
-  }
-
-  let backLink = null;
-  if (formdata.stepHistory && formdata.stepHistory.length > 0) {
-    backLink = `/acquirer/${resourceID}/${
-      formdata.stepHistory[formdata.stepHistory.length - 1]
-    }?action=back`;
-  } else {
-    backLink = `/acquirer/${resourceID}/start`;
-  }
-
   let returnedNotes, returnedNotesTitle;
   try {
     const shareRequestDetailResponse = await axios.get(
@@ -122,7 +123,6 @@ router.get("/:resourceID/check", async (req: Request, res: Response) => {
 
     res.render(`../views/acquirer/check.njk`, {
       requestId: formdata.requestId,
-      backLink,
       data: checkAnswer(formdata),
       returnedNotes,
       returnedNotesTitle,
@@ -158,21 +158,11 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
   }
   delete req.session.formErrors;
 
-  if (req.query.action === "back" && formdata.stepHistory) {
-    formdata.stepHistory.pop();
-  }
-
   if (
     stepData.status === "NOT REQUIRED" ||
     stepData.status === "CANNOT START YET"
   ) {
     return res.redirect(`/acquirer/${resourceID}/${stepData.nextStep}`);
-  }
-
-  let backLink = null;
-
-  if (!formdata.stepHistory) {
-    formdata.stepHistory = [];
   }
 
   // handle form errors
@@ -184,28 +174,17 @@ router.get("/:resourceID/:step", async (req: Request, res: Response) => {
     delete req.session.formValuesValidationError;
   }
 
-  if (formdata.stepHistory && formdata.stepHistory.length > 0) {
-    // Otherwise, set it to the previous step from stepHistory
-    backLink = `/acquirer/${resourceID}/${
-      formdata.stepHistory[formdata.stepHistory.length - 1]
-    }?action=back`;
-  } else {
-    backLink = `/acquirer/${resourceID}/start`;
-  }
-
   res.render(`../views/acquirer/${formStep}.njk`, {
     requestId: formdata.requestId,
     assetId: formdata.dataAsset,
     assetTitle,
     contactPoint: contactPoint,
-    backLink,
     stepId: formStep,
     savedValue: stepData.value,
     errorMessage: stepData.errorMessage,
   });
 });
 
-const URL = `${process.env.API_ENDPOINT}/sharedata`;
 
 router.post(
   "/:resourceID/:step",
@@ -227,10 +206,6 @@ router.post(
 
     stepData.value = extractFormData(stepData, req.body) || "";
 
-    if (!formdata.stepHistory) {
-      formdata.stepHistory = [];
-    }
-
     if (formStep === 'benefits') {
       const benefitsData = stepData.value
       for (const value of Object.values(benefitsData)) {
@@ -239,7 +214,7 @@ router.post(
         }
       }
     }
-    
+
     if (req.body.addCountry) {
       if (Array.isArray(formdata.steps["data-travel-location"].value)) {
         formdata.steps["data-travel-location"].value.push(""); // Add a new empty string.
@@ -308,17 +283,6 @@ router.post(
       formdata.status = "AWAITING REVIEW";
     }
 
-    // Check which button was clicked "Save and continue || Save and return"
-    let redirectURL = `/acquirer/${resourceID}/start`;
-    if (req.body.returnButton) {
-      // If save and return was clicked, clear the step history
-      formdata.stepHistory = [];
-    } else {
-      // Otherwise add the current step to the history if it's not already there
-      if (formdata.stepHistory.indexOf(formStep) === -1) {
-        formdata.stepHistory.push(formStep);
-      }
-    }
 
     if (req.body.continueButton && formStep === "confirmation") {
       return res.redirect(`/manage-shares/created-requests`);
@@ -333,6 +297,7 @@ router.post(
 
     const nextStep = formdata.steps[formStep].nextStep;
 
+    let redirectURL = `/acquirer/${resourceID}/start`;
     if (req.body.continueButton && nextStep) {
       redirectURL = `/acquirer/${resourceID}/${nextStep}`;
     }

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -39,7 +39,7 @@ const callApiAsAdmin = async (
     if (verb === "GET") {
       response = await axios.get(API(path), { headers });
     } else if (verb === "DELETE") {
-      response = await axios.delete(API(path), { headers })
+      response = await axios.delete(API(path), { headers });
     } else {
       response = await axios.put(API(path), { ...data }, { headers });
     }

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -74,7 +74,7 @@ router.get(
     const backLink = req.headers.referer || "/";
 
     const pendingRequests = response.filter((r) =>
-      ["IN PROGRESS", "RETURNED"].includes(r.status),
+      ["IN PROGRESS", "RETURNED", "NOT STARTED"].includes(r.status),
     );
     let pendingRows: ShareRequestTable = pendingRequests.map((r) => [
       {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -26,7 +26,6 @@ interface FormData {
   status: FormStatus;
   overviewSections: Record<string, Section>;
   steps: Record<string, Step>;
-  stepHistory?: string[];
 }
 
 interface ShareRequestResponse {


### PR DESCRIPTION
# Acquirer form NOT STARTED status
This PR fixes this issue:
> A request should be shown as in progress if we click start, not just if there is one question answered. For that scenario, if no questions have been answered, it should be saved as NOT STARTED in the created requests row.

# Changes
- Updated the initial status of the form in the template to `NOT STARTED`
- Added a call to the api in the `.../start` route, to send the acquirer form data to the API when the form is `NOT STARTED`
- Updated the `/created-requests` route to include `NOT STARTED` requests in the table
- Removed all reference to `stepHistory` - none of this is used any more now that the backlinks are fixed