### PR TITLE
add cookie route and content

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import loginRoutes from "./routes/loginRoutes";
 import authRoutes from "./routes/authRoutes";
 import profileRoutes from "./routes/profileRoutes";
 import manageRoutes from "./routes/supplierRoutes";
+import infoRoutes from "./routes/infoRoutes";
 import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
 import session from "express-session";
@@ -140,6 +141,7 @@ app.use("/cookie-settings", cookieRoutes);
 app.use("/learn", learnRoute);
 app.use("/learn/articles", learnArticleRoutes);
 app.use("/admin", adminRoutes);
+app.use("/", infoRoutes);
 
 // Error handling
 // Catch all route to handle errors

--- a/src/routes/infoRoutes.ts
+++ b/src/routes/infoRoutes.ts
@@ -1,0 +1,10 @@
+import express, { Request, Response } from "express";
+const router = express.Router();
+
+router.get("/cookies", (req: Request, res: Response) => {
+    res.render("cookies.njk", { route: "Cookies" });
+  })
+
+  // add Accessibility and Privacy
+
+  export default router;

--- a/src/views/cookies.njk
+++ b/src/views/cookies.njk
@@ -1,0 +1,56 @@
+{% extends "layouts/base.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Cookie statement</h1>
+    <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+    <p class="govuk-body">We use cookies to make the Data Marketplace service work and to collect information about how you use our service.</p>
+
+    <h1 class="govuk-heading-l">Essential cookies</h1>
+    <p class="govuk-body">We use only essential cookies to keep your information secure while you use the Data Marketplace service. We do not need to ask permission to use them.</p>
+    
+    {{ govukTable({
+  head: [
+    {
+      text: "Name"
+    },
+    {
+      text: "Purpose"
+    },
+    {
+      text: "Expires"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "session_cookie"
+      },
+      {
+        text: "Used to keep you signed in"
+      },
+      {
+        text: "20 hours"
+      }
+    ],
+    [
+       {
+        text: "cookie_policy"
+      },
+      {
+        text: "Saves your cookie consent settings"
+      },
+      {
+        text: "1 year"
+      }
+    ]
+  ]
+}) }}
+
+    <h1 class="govuk-heading-l">Analytics cookies</h1>
+    <p class="govuk-body">We do not use any analytics cookies to collect data about how you use the service.</p>
+</div>
+</div>
+{% endblock %}

--- a/src/views/partials/cookieBanner.njk
+++ b/src/views/partials/cookieBanner.njk
@@ -30,7 +30,7 @@
           },
           {
             text: "View cookies",
-            href: "#"
+            href: "/cookies"
           }
         ]
       }

--- a/src/views/partials/footer.njk
+++ b/src/views/partials/footer.njk
@@ -9,7 +9,7 @@
           text: "Accessibility"
         },
         {
-          href: "#",
+          href: "/cookies",
           text: "Cookies"
         },
         {


### PR DESCRIPTION
This PR adds the content of cookie statements. 
![Screenshot 2023-09-27 at 09 32 48](https://github.com/co-cddo/data-marketplace/assets/49984490/3f48635b-7cb6-469b-8205-2bdb6c477ec4)
