### PR TITLE
Add errors to upload summary

### DIFF
--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -70,17 +70,17 @@ router.get("/csv/upload-summary", async (req: Request, res: Response) => {
     const data = req.session.uploadData || [];
     const errors = req.session.uploadErrors || [];
     const rowErrors: UploadError[] = [];
-    let fileError: UploadError | null = null;
+    const fileErrors: UploadError[] = [];
     errors.forEach((e) => {
         if (e.scope == "FILE") {
-            fileError = e;
+            fileErrors.push(e);
         } else {
             rowErrors.push(e);
         }
     });
-    if (fileError) {
+    if (fileErrors.length > 0) {
         res.render("../views/publisher/file_error.njk", {
-            error: JSON.stringify(fileError, null, 2),
+            errors: fileErrors
         });
     } else {
         const uploadSummaries = data.map((dataset, index) => ({

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -59,11 +59,14 @@ router.post(
       req.session.uploadErrors = errs;
       return res.redirect("/publish/csv/upload-summary");
     } catch (err) {
-      console.error(err);
-      res.sendStatus(400);
+        return res.redirect("/publish/csv/upload/error");
     }
   },
 );
+
+router.get("/csv/upload/error", async (req: Request, res: Response) => {
+    res.render("../views/publisher/total_error.njk");
+})
 
 router.get("/csv/upload-summary", async (req: Request, res: Response) => {
     const backLink = req.headers.referer || "/";

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -105,14 +105,14 @@ router.get("/csv/upload-summary", async (req: Request, res: Response) => {
     };
 });
 
-router.get("/csv/preview/:id", async (req: Request, res: Response) => {
-  const assetId = Number(req.params.id);
+router.get("/csv/preview/:assetIndex", async (req: Request, res: Response) => {
+  const assetIndex = Number(req.params.assetIndex);
 
   if (!req.session.uploadData) {
     return res.status(400).send("Invalid asset ID or data is not available");
   }
 
-  const dataset = req.session.uploadData[assetId];
+  const dataset = req.session.uploadData[assetIndex];
 
   console.log("/publish/csv/preview specific asset", dataset)
   if (!dataset) {

--- a/src/views/publisher/asset-error.njk
+++ b/src/views/publisher/asset-error.njk
@@ -1,0 +1,49 @@
+{% extends "page.njk" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-xl">Asset error detail</h2>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Asset ID</dt>
+          <dd class="govuk-summary-list__value">{{ assetErr.location }}</dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Error</dt>
+          <dd class="govuk-summary-list__value">{{ assetErr.message }}</dd>
+        </div>
+      </dl>
+      {# TODO: as a stretch goal, we could use the field assetErr.extras.input_data to get all the valid
+      fields from the row, but time is tight so I'm not doing that right now #}
+      {% if assetErr.sub_errors.length > 0 %}
+        <h3 class="govuk-heading-l">Invalid fields</h3>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col"> Field </th>
+              <th class="govuk-table__header" scope="col"> Value </th>
+              <th class="govuk-table__header" scope="col"> Message </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+              {% for suberr in assetErr.sub_errors %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                      {{ suberr.location }}
+                  </td>
+                  <td class="govuk-table__cell">
+                      {{ suberr.value }}
+                  </td>
+                  <td class="govuk-table__cell">
+                      {{ suberr.message }}
+                  </td>
+                </tr>
+              {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+  </div>
+</div>
+
+{% endblock %}

--- a/src/views/publisher/file_error.njk
+++ b/src/views/publisher/file_error.njk
@@ -2,11 +2,41 @@
 
 {% block content %}
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">
-      Error with entire file
+        Errors parsing input
       </h1>
-      <pre style="border: 20x solid red;">{{ error }}</pre>
+      {% for err in errors %}
+      <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Location</dt>
+            <dd class="govuk-summary-list__value">
+              {% if err.location == "assetType.dataset file" %}
+                Datasets file
+              {% else %}
+                Data services file
+              {% endif %}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Error</dt>
+            <dd class="govuk-summary-list__value">{{ err.message }}</dd>
+          </div>
+          {% if err.message == "Incorrect headers in CSV" %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Unexpected headers found</dt>
+              <dd class="govuk-summary-list__value">{{ err.extras.invalid_cols }}</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Required headers are missing</dt>
+              <dd class="govuk-summary-list__value">{{ err.extras.missing_cols }}</dd>
+            </div>
+
+          {% endif %}
+        </dl>
+        </div>
+      {% endfor %}
 
   </div>
 </div>

--- a/src/views/publisher/total_error.njk
+++ b/src/views/publisher/total_error.njk
@@ -1,0 +1,22 @@
+{% extends "page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+          Malformed files
+      </h1>
+      <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <p class="govuk-body">
+           Your files could not be parsed. Please ensure that you have uploaded both sheets from the template as CSV files.
+        </p>
+      </div>
+  {{ govukButton({
+        text: "Try again",
+        href: "/publish/csv/upload",
+        name: "tryAgainButton"
+    }) }}
+  </div>
+</div>
+{% endblock %}

--- a/src/views/publisher/upload-summary.njk
+++ b/src/views/publisher/upload-summary.njk
@@ -1,5 +1,7 @@
 {% extends "page.njk" %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+
+<table class="govuk-table">
 
  {% block content %}
 <div class="govuk-grid-row">
@@ -37,23 +39,51 @@
     <h2 class="app-task-list__section">
     Data Harvesters
     </h2>
-    {{ govukTable({
-    caption: "Completed requests",
-    captionClasses: "govuk-table__caption--l",
-    classes: "request-tables",
-    head: [
-        {
-            text: "Data asset"
-        },
-        {
-            text: "Asset Type"
-        },
-        {
-            text: "Status"
-        }
-    ],
-    rows: uploadSummary
-}) }}
+
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col"> Data Asset </th>
+      <th class="govuk-table__header" scope="col"> Asset Type </th>
+      <th class="govuk-table__header" scope="col"> Status </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  {% for asset in uploadSummaries %}
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <a class="govuk-link" href="{{ asset.link }}">{{asset.linkText}}</a>
+      </td>
+      <td class="govuk-table__cell">
+        {{ asset.assetType }}
+      </td>
+      <td class="govuk-table__cell">
+        {{govukTag({
+          text: "PASS",
+          classes: "govuk-tag--blue"
+        })}}
+      </td>
+    </tr>
+  {% endfor %}
+  {% for err in errorSummaries %}
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <a class="govuk-link" href="{{ err.link }}">{{err.linkText}}</a>
+      </td>
+      <td class="govuk-table__cell">
+      </td>
+      <td class="govuk-table__cell">
+        {{govukTag({
+          text: "ERROR",
+          classes: "govuk-tag--red"
+        })}}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
   </div>
 </div>
 

--- a/src/views/publisher/upload-summary.njk
+++ b/src/views/publisher/upload-summary.njk
@@ -72,6 +72,7 @@
         <a class="govuk-link" href="{{ err.link }}">{{err.linkText}}</a>
       </td>
       <td class="govuk-table__cell">
+        {{ err.assetType }}
       </td>
       <td class="govuk-table__cell">
         {{govukTag({


### PR DESCRIPTION
After a user has uploaded a CSV, one of two things will happen:

a) The CSVs are unprocessable and they get redirected to an error page (currently very ugly just showing a json error)

b) The CSVs were processed by the API and we see the page that Amir wrote with a summary of all assets extracted from the files, but now it also has any errors in the table. So far, these do not link to the error detail pages but they soon will. Note that the asset type is missing from the table, as an unprocessed item doesn't have a type, and the ID is used instead of the name to identify it.