### PR TITLE
DMBM/936 - Missing govuk-link styling on markdown links

### DIFF
--- a/public/javascripts/linkStyling.js
+++ b/public/javascripts/linkStyling.js
@@ -1,0 +1,12 @@
+const addGovukClassToLinks = () => {
+  document.addEventListener("DOMContentLoaded", function() {
+    const links = document.querySelectorAll('.asset-description a');
+    if(links) {
+      links.forEach(link => {
+          link.classList.add('govuk-link');
+      });
+    }
+  });
+}
+
+addGovukClassToLinks()

--- a/src/views/find.njk
+++ b/src/views/find.njk
@@ -137,3 +137,11 @@
 </form>
 
 {% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}  
+    <script src="{{ assetPath }}/javascripts/accordionExpander.js" type="text/javascript"></script>
+    <script src="{{ assetPath }}/javascripts/removeFilter.js" type="text/javascript"></script>
+    <script src="{{ assetPath }}/javascripts/searchBar.js" type="text/javascript"></script>
+    <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -60,6 +60,7 @@
     <script src="{{ assetPath }}/javascripts/removeFilter.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/backLink.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/searchBar.js" type="text/javascript"></script>
+    <script src="{{ assetPath }}/javascripts/linkStyling.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/cookies.js" defer></script>
     <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -56,11 +56,7 @@
 {% block bodyEnd %}
   {{ super() }}  
     <script src="{{ assetPath }}/gov/all.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/accordionExpander.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/removeFilter.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/backLink.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/searchBar.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/linkStyling.js" type="text/javascript"></script>
     <script src="{{ assetPath }}/javascripts/cookies.js" defer></script>
     <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/resource.njk
+++ b/src/views/resource.njk
@@ -220,3 +220,9 @@
 </div>
 </div>
 {% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}  
+    <script src="{{ assetPath }}/javascripts/accordionExpander.js" type="text/javascript"></script>
+    <script src="{{ assetPath }}/javascripts/linkStyling.js" type="text/javascript"></script>
+{% endblock %}

--- a/src/views/resource.njk
+++ b/src/views/resource.njk
@@ -23,7 +23,7 @@
       <strong class="govuk-tag govuk-tag--grey">{{ resource.serviceType }}</strong>
       {% endif %}
     </p>
-    <div class="result-list__limit-height">
+    <div class="result-list__limit-height asset-description">
       <div class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-0">
         {% markdown %}
         {{ resource.description }}


### PR DESCRIPTION
This PR includes a script that adds the class `"govuk-link"` to any `<a>` tag in an asset's description. The descriptions we receive from partners may contain any kind of markdown which we render using nunjucks-markdown. Now, if there is an` <a>` tag, it will be styled the same as all the other links within the build.
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/44b4b3ba-7224-44cf-93ab-5058c7591821)
