### PR TITLE
Publisher UI

### DIFF
--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -92,13 +92,13 @@ router.get("/csv/upload-summary", async (req: Request, res: Response) => {
             assetType: dataset.type
         }));
         const errorSummaries = rowErrors.map((err, index) => {
-            const input_data: any = err.extras?.input_data || {};
-            const dataType = input_data.type;
-            return {
-                link: `/publish/csv/error/${index}`,
-                linkText: input_data.title || err.location,
-                assetType: input_data.type || "Undefined"
-            };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const input_data: any = err.extras?.input_data || {};
+          return {
+              link: `/publish/csv/error/${index}`,
+              linkText: input_data.title || err.location,
+              assetType: input_data.type || "Undefined"
+          };
         });
         const hasErrors: boolean = rowErrors.length > 0;
 

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -159,7 +159,7 @@ router.post("/commit", async (req: Request, res: Response) => {
     .then((response) => {
       req.session.uploadData = response.data.data;
       req.session.uploadErrors = response.data.errors;
-      return res.redirect("/publish/result");
+      return res.redirect("/publish/csv/confirmation");
     })
     .catch((error) => {
       console.error(error);
@@ -167,7 +167,7 @@ router.post("/commit", async (req: Request, res: Response) => {
     });
 });
 
-router.get("/result", async (req: Request, res: Response) => {
+router.get("/csv/confirmation", async (req: Request, res: Response) => {
   if (req.session.uploadErrors && req.session.uploadData) {
     if (req.session.uploadErrors.length > 0) {
       res.render("../views/publisher/post_publish.njk", {

--- a/src/views/publisher/csv_upload.njk
+++ b/src/views/publisher/csv_upload.njk
@@ -1,7 +1,6 @@
 {% extends "page.njk" %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -10,19 +9,7 @@
       Upload CSV file
     </h1>
     <p class="govuk-body">Upload the CSV files containing your data asset descriptions.</p>
-    <p class="govuk-body">Then upload the files, where it will be checked for errors.</p>
-
-    {% set uploadGuide %}
-      <p class="govuk-body">Ensure that the uploaded file types are of .CSV, you may need to export the template to CSV </p>
-      <p class="govuk-body">Ensure all mandatory fields in the template have data</p>
-      <p class="govuk-body">Upload the files, where they will be checked for errors.</p>
-      <p class="govuk-body">A few attempts might be needed to continue</p>
-    {% endset %}
-    {{ govukDetails({
-      summaryText: "Help with uploading your CSV files",
-      html: uploadGuide
-    }) }}
-
+    
     <form action="/publish/csv/upload" method="POST" enctype="multipart/form-data">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">

--- a/src/views/publisher/csv_upload.njk
+++ b/src/views/publisher/csv_upload.njk
@@ -1,55 +1,73 @@
 {% extends "page.njk" %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block content %}
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+ <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       Upload CSV file
     </h1>
-    <p class="govuk-body">Upload the CSV file containing your data asset descriptions.</p>
-    <p class="govuk-body">Then upload the file, where it will be checked for errors.</p>
-    <h4 class="govuk-heading-m">TODO: we need to instruct people to export the "dataset" and "data service" pages as CSV files</h4>
-    <form action="/publish/csv/upload" method="POST" enctype="multipart/form-data">
-      <div class="govuk-grid-column-one-half">
-        {{ govukFileUpload({
-          id: "datasetsCSV",
-          name: "datasetsCSV",
-          label: {
-            text: "Upload dataset CSV",
-            for: "datasetsCSV"
-          }
-        }) }}
-      </div>
+    <p class="govuk-body">Upload the CSV files containing your data asset descriptions.</p>
+    <p class="govuk-body">Then upload the files, where it will be checked for errors.</p>
 
-      <div class="govuk-grid-column-one-half">
-      {{ govukFileUpload({
-        id: "servicesCSV",
-        name: "servicesCSV",
-        label: {
-          text: "Upload dataService CSV",
-          for: "servicesCSV"
-        }
-      }) }}
+    {% set uploadGuide %}
+      <p class="govuk-body">Ensure that the uploaded file types are of .CSV, you may need to export the template to CSV </p>
+      <p class="govuk-body">Ensure all mandatory fields in the template have data</p>
+      <p class="govuk-body">Upload the files, where they will be checked for errors.</p>
+      <p class="govuk-body">A few attempts might be needed to continue</p>
+    {% endset %}
+    {{ govukDetails({
+      summaryText: "Help with uploading your CSV files",
+      html: uploadGuide
+    }) }}
+
+    <form action="/publish/csv/upload" method="POST" enctype="multipart/form-data">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          {{ govukFileUpload({
+            id: "datasetsCSV",
+            name: "datasetsCSV",
+            label: {
+              text: "Upload dataset CSV",
+              for: "datasetsCSV"
+            }
+          }) }}
+        </div>
+        <div class="govuk-grid-column-one-half">
+            {{ govukFileUpload({
+                id: "servicesCSV",
+                name: "servicesCSV",
+                label: {
+                    text: "Upload dataService CSV",
+                    for: "servicesCSV"
+                }
+            }) }}
+        </div>
       </div>
-        <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+      {{ govukButton({
+          text: "Continue",
+          attributes: {
+              type: "submit"
+          }
+      }) }}
     </form>
-    </div>
-  
-    <div class="govuk-grid-column-one-third">
-      <aside class="app-related-items learn-aside" role="complementary">
+</div>
+
+<div class="govuk-grid-column-one-third">
+    <aside class="app-related-items learn-aside" role="complementary">
         <h2 class="govuk-heading-s govuk-!-margin-top-3 govuk-!-margin-bottom-3" id="subsection-title">
           Learn
         </h2>
         <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-!-font-size-16">
-              <li><a href="/learn/articles/metadata-model" class="govuk-link">Metadata sharing requirements</a></li>
-              <li><a href="/learn/articles/metadata-model" class="govuk-link">Adding a collection of metadata records as a CSV file</a></li>
-          </ul>
+            <ul class="govuk-list govuk-!-font-size-16">
+                <li><a href="/learn/articles/metadata-model" class="govuk-link">Metadata sharing requirements</a></li>
+                <li><a href="/learn/articles/metadata-model" class="govuk-link">Adding a collection of metadata records as a CSV file</a></li>
+            </ul>
         </nav>
-      </aside>
-    </div>   
-  </div>
+    </aside>
+</div>   
 </div>
 
 {% endblock %} 

--- a/src/views/publisher/post_publish.njk
+++ b/src/views/publisher/post_publish.njk
@@ -1,14 +1,28 @@
 {% extends "layouts/base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
-    {% if hasError %}
-      <h2 class="govuk-heading-l govuk-!-font-weight-bold">Something went wrong</h2>
-      <p> {{ error }}
-    {% else %}
-      <h2 class="govuk-heading-l govuk-!-font-weight-bold">Success!</h2>
-      <p> {{ numPublished }} records added</p>
-    {% endif %}
+  {% if hasError %}
+    <h2 class="govuk-heading-l govuk-!-font-weight-bold">Something went wrong</h2>
+    <p> {{ error }}
+  {% else %}
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+      titleText: "CSV file uploaded"
+    }) }}
+    <p class="govuk-body">Your data asset descriptions have been uploaded to the data marketplace.</p>
+    <p class="govuk-body">They are now available to be found by other government organisations searching for a data asset. </p>
+    <form action="/publish/commit" method="POST">
+      {{ govukButton({
+        text: "Return to publisher dashboard",
+        href: "/publish/publish-dashboard"
+      }) }}
+    </form>
+  </div>
+  {% endif %}
 </div>
-{% endblock %} 
+
+{% endblock %}  

--- a/src/views/publisher/preview.njk
+++ b/src/views/publisher/preview.njk
@@ -25,7 +25,11 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Description</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.description }}</dd>
+          <dd class="govuk-summary-list__value">
+            {% markdown %}
+              {{ dataset.description }}
+            {% endmarkdown %}
+          </dd>
         </div>
 
         <div class="govuk-summary-list__row">
@@ -34,20 +38,20 @@
         </div>
 
         <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Keywords</dt>
-        <dd class="govuk-summary-list__value">
-          {% for keyword in dataset.keyword %}
-            {{ keyword }}{% if not loop.last %}, {% endif %}
-          {% endfor %}
-        </dd>
-      </div>
+          <dt class="govuk-summary-list__key">Keywords</dt>
+          <dd class="govuk-summary-list__value">
+            {% for keyword in dataset.keyword %}
+              {{ keyword }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </dd>
+        </div>
 
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Themes</dt>
           <dd class="govuk-summary-list__value">
             {% for theme in dataset.theme %}
-              {{ theme }}
+            <a class="govuk-link" target="_blank" href="{{ theme }}">{{ theme }}</a>
               {% if not loop.last %}, {% endif %}
             {% endfor %}
           </dd>
@@ -55,8 +59,20 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Point of Contact</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.contactPoint.name }} (Email: {{ dataset.contactPoint.email }})</dd>
-        </div>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list govuk-list--bullet">
+              {% for key, value in dataset.contactPoint %}
+                <li>
+                  {% if key == 'email' %}
+                    <a class="govuk-link" href="mailto:{{ value }}">{{ value }}</a>
+                  {% else %}
+                    {{ key }}: {{ value }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </dd>
+        </div>       
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Version</dt>
@@ -70,7 +86,7 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Licence</dt>
-          <dd class="govuk-summary-list__value"><a class="govuk-link" target="_blank" href="{{ dataset.licence }}">License Link</a></dd>
+          <dd class="govuk-summary-list__value"><a class="govuk-link" target="_blank" href="{{ dataset.licence }}">{{ dataset.licence }}</a></dd>
         </div>
 
         <div class="govuk-summary-list__row">
@@ -95,20 +111,21 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Date Issued</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.issued }}</dd>
+          <dd class="govuk-summary-list__value">{{ dataset.issued | formatDate}}</dd>
         </div>
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Date Modified</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.modified }}</dd>
+          <dd class="govuk-summary-list__value">{{ dataset.modified | formatDate}}</dd>
         </div>
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Related data</dt>
           <dd class="govuk-summary-list__value">
             {% for relatedData in dataset.relatedAssets %}
-              <a class="govuk-link" target="_blank" href="{{ relatedData }}">Link</a>
-              {% if not loop.last %}, {% endif %}
+              <a class="govuk-link" target="_blank" href="{{ relatedData }}">{{ relatedData }}</a>
+              <br>
+              <br>
             {% endfor %}
           </dd>
         </div>
@@ -158,31 +175,98 @@
       {% endfor %}
     {% endif %}
     {% if dataset.type == 'DataService' %}
-      <h2>Data Service Details</h2>
+      <h2 class="govuk-heading-xl">Dataservice Description</h2>
       <dl class="govuk-summary-list">
-
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Title</dt>
           <dd class="govuk-summary-list__value">{{ dataset.title }}</dd>
         </div>
 
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Modified</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.modified }}</dd>
+          <dt class="govuk-summary-list__key">Service type</dt>
+          <dd class="govuk-summary-list__value">{{ dataset.serviceType }}</dd>
         </div>
 
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Endpoint</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.endpointURL }}</dd>
+          <dt class="govuk-summary-list__key">Service status</dt>
+          <dd class="govuk-summary-list__value">{{ dataset.serviceStatus }}</dd>
+        </div>
+        
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Description</dt>
+          <dd class="govuk-summary-list__value">
+            {% markdown %}
+              {{ dataset.description }}
+            {% endmarkdown %}
+          </dd>
         </div>
 
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Access URL</dt>
-          <dd class="govuk-summary-list__value">{{ dataset.accessURL }}</dd>
+          <dt class="govuk-summary-list__key">Summary</dt>
+          <dd class="govuk-summary-list__value">
+            {% markdown %}
+              {{ dataset.summary }}
+            {% endmarkdown %}
+          </dd>
         </div>
 
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Keywords</dt>
+          <dd class="govuk-summary-list__value">
+            {% for keyword in dataset.keyword %}
+              {{ keyword }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Endpoint URL</dt>
+          <dd class="govuk-summary-list__value"><a class="govuk-link" target="_blank" href="{{ dataset.endpointURL }}">{{ dataset.endpointURL }}</a></dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Endpoint Description</dt>
+          <dd class="govuk-summary-list__value"><a class="govuk-link" target="_blank" href="{{ dataset.endpointDescription }}">{{ dataset.endpointDescription }}</a></dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Licence</dt>
+          <dd class="govuk-summary-list__value"><a class="govuk-link" target="_blank" href="{{ dataset.licence }}">{{ dataset.licence }}</a></dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Access rights</dt>
+          <dd class="govuk-summary-list__value">{{ dataset.accessRights }}</dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Security Classification</dt>
+          <dd class="govuk-summary-list__value">{{ dataset.securityClassification }}</dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Version</dt>
+          <dd class="govuk-summary-list__value">{{ dataset.version }}</dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Point of Contact</dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list govuk-list--bullet">
+              {% for key, value in dataset.contactPoint %}
+                <li>
+                  {% if key == 'email' %}
+                    <a class="govuk-link" href="mailto:{{ value }}">{{ value }}</a>
+                  {% else %}
+                    {{ key }}: {{ value }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </dd>
+        </div>
       </dl>
-    {% endif %}
+      {% endif %}
   </div>
 </div>
 

--- a/src/views/publisher/upload-summary.njk
+++ b/src/views/publisher/upload-summary.njk
@@ -35,56 +35,51 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <!-- Harvesters info to be added in later iterations -->
-    <h2 class="app-task-list__section">
-    Data Harvesters
-    </h2>
-
-
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col"> Data Asset </th>
-      <th class="govuk-table__header" scope="col"> Asset Type </th>
-      <th class="govuk-table__header" scope="col"> Status </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  {% for asset in uploadSummaries %}
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">
-        <a class="govuk-link" href="{{ asset.link }}">{{asset.linkText}}</a>
-      </td>
-      <td class="govuk-table__cell">
-        {{ asset.assetType }}
-      </td>
-      <td class="govuk-table__cell">
-        {{govukTag({
-          text: "PASS",
-          classes: "govuk-tag--blue"
-        })}}
-      </td>
-    </tr>
-  {% endfor %}
-  {% for err in errorSummaries %}
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">
-        <a class="govuk-link" href="{{ err.link }}">{{err.linkText}}</a>
-      </td>
-      <td class="govuk-table__cell">
-        {{ err.assetType }}
-      </td>
-      <td class="govuk-table__cell">
-        {{govukTag({
-          text: "ERROR",
-          classes: "govuk-tag--red"
-        })}}
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"> Data Asset </th>
+            <th class="govuk-table__header" scope="col"> Asset Type </th>
+            <th class="govuk-table__header" scope="col"> Status </th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for asset in uploadSummaries %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <a class="govuk-link" href="{{ asset.link }}">{{asset.linkText}}</a>
+            </td>
+            <td class="govuk-table__cell">
+              {{ asset.assetType }}
+            </td>
+            <td class="govuk-table__cell">
+              {{govukTag({
+                text: "PASS",
+                classes: "govuk-tag--blue"
+              })}}
+            </td>
+          </tr>
+        {% endfor %}
+        {% for err in errorSummaries %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <a class="govuk-link" href="{{ err.link }}">{{err.linkText}}</a>
+            </td>
+            <td class="govuk-table__cell">
+              {{ err.assetType }}
+            </td>
+            <td class="govuk-table__cell">
+              {{govukTag({
+                text: "ERROR",
+                classes: "govuk-tag--red"
+              })}}
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/src/views/publisher/upload-summary.njk
+++ b/src/views/publisher/upload-summary.njk
@@ -1,5 +1,6 @@
 {% extends "page.njk" %}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 <table class="govuk-table">
 
@@ -79,6 +80,19 @@
         {% endfor %}
         </tbody>
       </table>
+      <form action="/publish/commit" method="POST">
+        {{ govukButton({
+          text: "Publish data asset description",
+          attributes: {
+            type: "submit"
+          }
+        }) }}
+        {{ govukButton({
+          text: "Re-upload CSV file",
+          href: "/publish/csv/upload",
+          classes: "govuk-button--secondary"
+        }) }}
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR adds UI for the publisher journey, clicking 
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/a1120223-085b-4665-83c1-1a1c03fa98b8)
on the Data Marketplace landing page

We are taken to:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/b0b35c82-cc09-4208-bb0b-b6a19734a6e0)
The Values you see on the page here, will be hard coded:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/c926c605-c3a6-4615-9dff-ee2391efc4f3)

clicking the `Add a new data description` will take you to this page:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/aa5a7127-a4a4-4c88-95c9-88420f1bb698)
which the user is able to download the template. When the user is satisfied, once they click `Publish from CSV` the user will then see this page:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/42e2d1a7-9f6f-4ba9-b686-253610685e8d)

it is important to note that this page is due to change, currently @kjoshi has implemented a fix in ("a branch yet to be made as a PR")

There will be one upload a file section, with reduced text.

Once the user has uploaded their files and hits the "Continue" button they then see the upload-summary page:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/a4ca5689-ede0-4fd0-a762-f163e59b021f)

the user can click between the `Datasets` or `DataService` which will show the details from the uploaded CSV, example of a dataservice asset in preview:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/fcbf837a-625b-48c1-9c2b-6ec899924ff1)
example of a dataset asset in preview:
![image](https://github.com/co-cddo/data-marketplace/assets/71328022/4ebca1cf-cfea-4cf0-99f2-9760998979d7)







