### PR TITLE
DMBM-980/ internal data licence link

### DIFF
--- a/src/views/resource.njk
+++ b/src/views/resource.njk
@@ -122,15 +122,19 @@
     {% endif %}
     <h2 class="govuk-heading-l">Further information</h2>
     <table class="govuk-table govuk-!-margin-bottom-8">
-      <tbody class="govuk-table__body">
+    <tbody class="govuk-table__body">
         {% if resource.licence %}
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header  govuk-!-width-one-half">Licence</th>
-          <td class="govuk-table__cell  govuk-!-width-one-half">        
-            <a href="{{ resource.licence }}" class="govuk-link">
-            {{ resource.licenceTitle }}
-            </a>
-          </td>
+            <th scope="row" class="govuk-table__header  govuk-!-width-one-half">Licence</th>
+            <td class="govuk-table__cell  govuk-!-width-one-half">
+                {% if resource.licence == "http://marketplace.cddo.gov.uk/licence/internal" %}
+                    Data Share Agreement is required
+                {% else %}
+                    <a href="{{ resource.licence }}" class="govuk-link">
+                        {{ resource.licenceTitle }}
+                    </a>
+                {% endif %}
+            </td>
         </tr>
         {% endif %}
         <tr class="govuk-table__row">

--- a/src/views/resource.njk
+++ b/src/views/resource.njk
@@ -127,8 +127,8 @@
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header  govuk-!-width-one-half">Licence</th>
             <td class="govuk-table__cell  govuk-!-width-one-half">
-                {% if resource.licence == "http://marketplace.cddo.gov.uk/licence/internal" %}
-                    Data Share Agreement is required
+                {% if resource.licence === "http://marketplace.cddo.gov.uk/licence/internal" %}
+                    Data share agreement required
                 {% else %}
                     <a href="{{ resource.licence }}" class="govuk-link">
                         {{ resource.licenceTitle }}


### PR DESCRIPTION
If the licence of an asset is set to the default value (if a value isn't provided when the data is loaded in), we display the text: 'Data share agreement required' and remove the link.
![image](https://github.com/co-cddo/data-marketplace/assets/107464669/a5d5a74c-1f75-468a-81e4-8d2a2951678a)
