### PR TITLE
Validation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-marketplace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "imagename": "dm-frontend",
   "description": "",
   "main": "index.js",

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -21,7 +21,8 @@ const publishDataAbacMiddleware = createAbacMiddleware(
 router.use(publishDataAbacMiddleware);
 
 router.get("/publish-dashboard", async (req: Request, res: Response) => {
-  res.render("../views/publisher/publish-dashboard.njk");
+  res.render("../views/publisher/publish-dashboard.njk",
+    { organisation: req.user.organisation?.title });
 });
 
 router.get("/csv/start", async (req: Request, res: Response) => {

--- a/src/views/publisher/asset-error.njk
+++ b/src/views/publisher/asset-error.njk
@@ -1,8 +1,8 @@
 {% extends "page.njk" %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-xl">Asset error detail</h2>
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
@@ -27,23 +27,27 @@
             </tr>
           </thead>
           <tbody class="govuk-table__body">
-              {% for suberr in assetErr.sub_errors %}
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">
-                      {{ suberr.location }}
-                  </td>
-                  <td class="govuk-table__cell">
-                      {{ suberr.value }}
-                  </td>
-                  <td class="govuk-table__cell">
-                      {{ suberr.message }}
+            {% for suberr in assetErr.sub_errors %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  {{ suberr.location }}
+                </td>
+                <td class="govuk-table__cell">
+                  {{ suberr.value }}
+                </td>
+                <td class="govuk-table__cell">
+                  {{ suberr.message | safe }}
+                  {% if suberr.extras["valid_options"] | length %}
+                    <br/>
+                    Valid options: {{suberr.extras["valid_options"]}}.
+                    {% endif%}
                   </td>
                 </tr>
               {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
-  </div>
-</div>
+            </tbody>
+          </table>
+        {% endif %}
+      </div>
+    </div>
 
-{% endblock %}
+  {% endblock %}

--- a/src/views/publisher/publish-dashboard.njk
+++ b/src/views/publisher/publish-dashboard.njk
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl ">
-            Department for Levelling Up, Housing and Communities published data descriptions
+            {{organisation}} published data descriptions
         </h1>
         <p class="govuk-body">Here's where you manage your data descriptions. Each government department has their own page.</p>
     </div>


### PR DESCRIPTION
# Validation fixes
This PR makes some minor updates to UI to take into account the [corresponding validation fixes made to the API](https://github.com/co-cddo/data-marketplace-api/pull/41).

## Changes
- Use `| safe` to display HTML in the validation error messages, because the API now returns links to the x-gov metadata model in some cases
- If `valid_options` are returned, show them in the table of errors.
- Also made some unrelated changes to the publish dashboard, to remove the hard-coded organisation name.