### PR TITLE
DMBM-1091: Backlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-marketplace",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "imagename": "dm-frontend",
   "description": "",
   "main": "index.js",

--- a/src/middleware/backMiddleware.ts
+++ b/src/middleware/backMiddleware.ts
@@ -2,22 +2,36 @@ import { NextFunction, Request, Response } from "express";
 
 export function backLink(req: Request, res: Response, next: NextFunction) {
   const fromBack = req.query.fromBack === "true";
-  req.session.pageHistory = req.session.pageHistory || [];
-  const urlIndex = req.session.pageHistory.indexOf(req.url);
+  req.session.pageHistory = req.session.pageHistory || ["/"];
+  req.session.previousUrl = req.session.previousUrl || "";
 
-  if (
-    req.method === "GET" &&
-    !fromBack && //dont add the page you just went back to, otherwise you get a loop
-    !req.session.pageHistory.includes(req.url)
-  ) {
-    req.session.pageHistory.push(req.url);
-    const maxHistoryLength = 5;
-    if (req.session.pageHistory.length > maxHistoryLength) {
-      req.session.pageHistory.shift();
-    }
-  } else {
-    req.session.pageHistory.splice(urlIndex, 1);
+  // If we end up back on the home page, clear the history
+  if (["/", "/?fromBack=true"].includes(req.url)) {
+    req.session.pageHistory = ["/"];
+    req.session.previousUrl = "/";
+    return next();
   }
+
+  // If we're on the same page as previously (I.e. refresh or redirect back):
+  // don't change the history
+  if (req.session.previousUrl && req.session.previousUrl === req.url) {
+    res.locals.pageHistory = req.session.pageHistory;
+    return next();
+  }
+
+  // If we've pressed the back link, remove the last element from the history
+  if (
+    fromBack
+  ) {
+    req.session.previousUrl = req.session.pageHistory.pop();
+    res.locals.pageHistory = req.session.pageHistory;
+    return next();
+  }
+
+  if (req.method === "GET" && !fromBack && req.session.previousUrl) {
+    req.session.pageHistory.push(req.session.previousUrl);
+  }
+  req.session.previousUrl = req.url;
   res.locals.pageHistory = req.session.pageHistory;
   next();
 }

--- a/src/routes/findRoutes.ts
+++ b/src/routes/findRoutes.ts
@@ -148,8 +148,8 @@ router.get("/:resourceID", async (req: Request, res: Response) => {
   if (!resource) {
     return res.render("error.njk", {
       messageTitle: "Data asset error",
-      messageBody: `Data asset with ID ${resourceID} cannot be retrieved.<br/><br/>Please <a href="https://forms.gle/MgZ5j7T6hXptEATJ7" class="govuk-link">use our feedback form</a> to let us know.`
-    })
+      messageBody: `Data asset with ID ${resourceID} cannot be retrieved.<br/><br/>Please <a href="https://forms.gle/MgZ5j7T6hXptEATJ7" class="govuk-link">use our feedback form</a> to let us know.`,
+    });
   }
 
   if (resource.distributions) {

--- a/src/services/findService.ts
+++ b/src/services/findService.ts
@@ -50,12 +50,11 @@ export async function fetchResourceById(
     if (!response) {
       return null;
     }
-
   } catch (error: unknown) {
-    console.error(`Error fetching resource: ${resourceID}`)
+    console.error(`Error fetching resource: ${resourceID}`);
     if (axios.isAxiosError(error)) {
-      console.error(`Error status: ${error.response?.status}`)
-      console.error("Please check the API logs for details")
+      console.error(`Error status: ${error.response?.status}`);
+      console.error("Please check the API logs for details");
     }
     return null;
   }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -306,6 +306,7 @@ declare module "express-session" {
     decisionErrors: { [key: string]: { text: string } };
     decision: { status: string; notes: string };
     formValuesValidationError: RequestBody;
+    previousUrl: string;
     pageHistory: string[];
     returnTo: string;
   }

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -3,18 +3,18 @@
 {% block pageTitle %}Data Marketplace{% endblock %}
 
 {% block head %}
-    <link href="{{ assetPath }}/stycssles/style.css" rel="stylesheet" />
+  <link href="{{ assetPath }}/stycssles/style.css" rel="stylesheet"/>
 {% endblock %}
 
 {% block header %}
-{% include "../partials/cookieBanner.njk" %}
-{{ govukHeader({
+  {% include "../partials/cookieBanner.njk" %}
+  {{ govukHeader({
   homepageUrl: "https://www.gov.uk",
   serviceName: "Data Marketplace",
   serviceUrl: "/",
   containerClasses: "govuk-width-container"
 }) }}
-{% include "partials/navigation.njk" %}
+  {% include "partials/navigation.njk" %}
   {% if home %}
     <div class="x-govuk-masthead x-govuk-masthead--large">
       <div class="govuk-width-container">
@@ -31,36 +31,37 @@
         </div>
       </div>
     </div>
-{% else %}
-  <div class="govuk-width-container">
-    {% if not noBackLink %}
-      {% include "partials/phaseBanner.njk" %}
-      {% if pageHistory.length >= 2 %}
-        {% if '?' in pageHistory[pageHistory.length - 2] %}
-          {% set separator = '&' %}
-        {% else %}
-          {% set separator = '?' %}
+  {% else %}
+    <div class="govuk-width-container">
+      {% if not noBackLink %}
+        {% include "partials/phaseBanner.njk" %}
+        {% if pageHistory.length > 0 %}
+          {% set backLinkUrl = pageHistory[pageHistory.length - 1] %}
+          {% if '?' in backLinkUrl %}
+            {% set separator = '&' %}
+          {% else %}
+            {% set separator = '?' %}
+          {% endif %}
+          <a id="history-back-link" class="govuk-back-link" href="{{backLinkUrl}}{{ separator }}fromBack=true">Back</a>
         {% endif %}
-        <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[pageHistory.length - 2] }}{{ separator }}fromBack=true">Back</a>
-      {% elif pageHistory.length == 1 %}
-        <a id="history-back-link" class="govuk-back-link" href="{{ pageHistory[0] }}?fromBack=true">Back</a>
-      {% else %}
-        <a id="history-back-link" class="govuk-back-link" href="/?fromBack=true">Back</a>
       {% endif %}
-    {% endif %}
-  </div>
-{% endif %}
+    </div>
+  {% endif %}
 
 {% endblock %}
 
 {% block bodyEnd %}
-  {{ super() }}  
-    <script src="{{ assetPath }}/gov/all.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/backLink.js" type="text/javascript"></script>
-    <script src="{{ assetPath }}/javascripts/cookies.js" defer></script>
-    <script>window.GOVUKFrontend.initAll()</script>
+  {{ super() }}
+  <script src="{{ assetPath }}/gov/all.js" type="text/javascript"></script>
+  {# <script src="{{ assetPath }}/javascripts/backLink.js" type="text/javascript"></script> #}
+  <script src="{{ assetPath }}/javascripts/cookies.js" defer></script>
+  <script>
+    window
+      .GOVUKFrontend
+      .initAll()
+  </script>
 {% endblock %}
 
 {% block footer %}
   {% include "../partials/footer.njk" %}
-{% endblock%}
+  {% endblock%}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -25,7 +25,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds-from-desktop">
             <p class="x-govuk-masthead__description govuk-!-margin-bottom-3">
-              A place for people who work in government  organisations, agencies and public bodies to share data.
+              A place for people who work in government organisations, agencies and public bodies to share data.
             </p>
           </div>
         </div>

--- a/src/views/permissionsError.njk
+++ b/src/views/permissionsError.njk
@@ -18,7 +18,7 @@
         href: "https://forms.gle/rpy2BMchHGDNVFfAA",
         text: "Request Permission"
       })}}
-        <a class="govuk-link" href="{{ pageHistory[pageHistory.length - 2] }}?fromBack=true">Back</a>
+        <a class="govuk-link" href="{{ pageHistory[pageHistory.length - 1] }}?fromBack=true">Back</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR addresses the issue described in [DMBM-1091](https://cddodatamarketplace.atlassian.net/browse/DMBM-1091), where the back links on the "You need permission" page did not work if you were redirected that page after signing in.

This problem arose because the backlink functionality was implemented using `window.history.back();` which can end up redirecting the user back into the SSO process. 

E.g. A user might click on the `Publish data descriptions` page, get redirected to the SSO sign-in and then back to the `publish-dashboard` page. But if the user doesn't have permission to publish, they would get shown the `You need permission page`. `window.history.back();` would then direct the user back into the SSO flow, and would ultimately redirect them back to the `publish-dashboard` page, leaving the user unable to get out of a loop.

This has been fixed by disabling the backlink code in `backLink.js` and using the user's session to keep track of the backlinks. There were a few bugs and edge cases in `backMiddleware` which I've fixed. 

One remaining issue is that when a user gets redirected away to the SSO their session gets reset. So in these cases the backlink will take the user back to the Data Marketplace home page.