### PR TITLE
Publish dashboard

### DIFF
--- a/src/middleware/backMiddleware.ts
+++ b/src/middleware/backMiddleware.ts
@@ -20,9 +20,7 @@ export function backLink(req: Request, res: Response, next: NextFunction) {
   }
 
   // If we've pressed the back link, remove the last element from the history
-  if (
-    fromBack
-  ) {
+  if (fromBack) {
     req.session.previousUrl = req.session.pageHistory.pop();
     res.locals.pageHistory = req.session.pageHistory;
     return next();

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -28,9 +28,30 @@ const publishDataAbacMiddleware = createAbacMiddleware(
 
 router.use(publishDataAbacMiddleware);
 
+type AssetCountsResponse = {
+  Dataset: number;
+  DataService: number;
+}
+
 router.get("/publish-dashboard", async (req: Request, res: Response) => {
+  const url = `${process.env.API_ENDPOINT}/asset-counts`
+  let numDatasets = 0;
+  let numDataServices = 0;
+  try {
+    const response = await axios.get(url, {
+      headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
+    })
+    const assetCounts = response.data as AssetCountsResponse
+    numDatasets = assetCounts["Dataset"]
+    numDataServices = assetCounts["DataService"]
+  } catch (error: unknown) {
+    console.error(error)
+    return res.render("../views/error.njk", { messageTitle: "API Error", messageBody: "Failed to retrive the publish dashboard statistics. See the API logs for details." })
+  }
   res.render("../views/publisher/publish-dashboard.njk", {
     organisation: req.user.organisation?.title,
+    numDatasets,
+    numDataServices
   });
 });
 

--- a/src/routes/publisherRoutes.ts
+++ b/src/routes/publisherRoutes.ts
@@ -31,27 +31,31 @@ router.use(publishDataAbacMiddleware);
 type AssetCountsResponse = {
   Dataset: number;
   DataService: number;
-}
+};
 
 router.get("/publish-dashboard", async (req: Request, res: Response) => {
-  const url = `${process.env.API_ENDPOINT}/asset-counts`
+  const url = `${process.env.API_ENDPOINT}/asset-counts`;
   let numDatasets = 0;
   let numDataServices = 0;
   try {
     const response = await axios.get(url, {
       headers: { Authorization: `Bearer ${req.cookies.jwtToken}` },
-    })
-    const assetCounts = response.data as AssetCountsResponse
-    numDatasets = assetCounts["Dataset"]
-    numDataServices = assetCounts["DataService"]
+    });
+    const assetCounts = response.data as AssetCountsResponse;
+    numDatasets = assetCounts["Dataset"];
+    numDataServices = assetCounts["DataService"];
   } catch (error: unknown) {
-    console.error(error)
-    return res.render("../views/error.njk", { messageTitle: "API Error", messageBody: "Failed to retrive the publish dashboard statistics. See the API logs for details." })
+    console.error(error);
+    return res.render("../views/error.njk", {
+      messageTitle: "API Error",
+      messageBody:
+        "Failed to retrive the publish dashboard statistics. See the API logs for details.",
+    });
   }
   res.render("../views/publisher/publish-dashboard.njk", {
     organisation: req.user.organisation?.title,
     numDatasets,
-    numDataServices
+    numDataServices,
   });
 });
 

--- a/src/views/publisher/publish-dashboard.njk
+++ b/src/views/publisher/publish-dashboard.njk
@@ -4,101 +4,102 @@
 
 {% block content %}
 
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl ">
-            {{organisation}} published data descriptions
+      <h1 class="govuk-heading-xl ">
+        {{organisation}} published data descriptions
         </h1>
-        <p class="govuk-body">Here's where you manage your data descriptions. Each government department has their own page.</p>
+      <p class="govuk-body">Here's where you manage your data descriptions. Each government department has their own page.</p>
     </div>
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-        {{ govukButton({
+      {{ govukButton({
             text: "Add new data description",
             href: "/publish/csv/start"
         }) }}
     </div>
 
     <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
-        <h2 class="govuk-heading-l">
+      <h2 class="govuk-heading-l">
             Your published metadata records
         </h2>
-        <dl class="publish-metrics">
+      <dl class="publish-metrics">
         <div class="publish-metric">
-            <dt><h3 class="govuk-heading-m">Datasets</h3></dt>
-            <dd><p class="govuk-body">0 published datasets</p></a></dd>
-        </div>
-        <div class="publish-metric">
-            <dt><h3 class="govuk-heading-m">Data services</h3></dt>
-            <dd><p class="govuk-body">0 published data services</p></dd>
-        </div>
-        <div class="publish-metric">
-            <dt><h3 class="govuk-heading-m">Pending share requests</h3></dt>
-            <dd><p class="govuk-body">No pending Datasets</p></dd>
-        </div>
-        <div class="publish-metric">
-            <dt><h3 class="govuk-heading-m">Submitted share requests</h3></dt>
-            <dd><p class="govuk-body">0 Data share requests</p></dd>
-        </div>
-        <div class="publish-metric">
-            <dt><h3 class="govuk-heading-m">Completed data shares</h3></dt>
-            <dd><p class="govuk-body">0 Completed data shares</a></p></dd>
-        </div>
-        </dl>
-    </div>
+          <dt>
+            <h3 class="govuk-heading-m">Datasets</h3>
+          </dt>
+          <dd>
+            <p class="govuk-body">{{numDatasets}} published dataset{% if numDatasets > 1 %}s{% endif %}
+            </p>
+          </a>
+        </dd>
+      </div>
+      <div class="publish-metric">
+        <dt>
+          <h3 class="govuk-heading-m">Data services</h3>
+        </dt>
+        <dd>
+          <p class="govuk-body">{{numDataServices}} published data service{% if numDataServices > 1 %}s{% endif %}
+          </p>
+        </dd>
+      </div>
+    </dl>
+  </div>
 
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-full">
 
-        <div class="gem-c-related-navigation">
-          <h2 id="learnLinks" class="gem-c-related-navigation__main-heading">
+      <div class="gem-c-related-navigation">
+        <h2 id="learnLinks" class="gem-c-related-navigation__main-heading">
             Learn
           </h2>
-          <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="learnLinks">
-            <ul class="gem-c-related-navigation__link-list">
-              
-              <li class="gem-c-related-navigation__link">
-                <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/guidance-on-publish">Publishing data descriptions</a>
-              </li>
-              <li class="gem-c-related-navigation__link">
-                <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/metadata-model">Metadata sharing requirements</a>
-              </li>
-              <li class="gem-c-related-navigation__link">
-                <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/adding-a-single-data-asset">Adding a single data description</a>
-              </li>
-              <li class="gem-c-related-navigation__link">
-                <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/adding-a-CSV-file">Adding a collection of metadata records as a CSV file</a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-        </div>
-        </div>
+        <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="learnLinks">
+          <ul class="gem-c-related-navigation__link-list">
+
+            <li class="gem-c-related-navigation__link">
+              <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/guidance-on-publish">Publishing data descriptions</a>
+            </li>
+            <li class="gem-c-related-navigation__link">
+              <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/metadata-model">Metadata sharing requirements</a>
+            </li>
+            <li class="gem-c-related-navigation__link">
+              <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/adding-a-single-data-asset">Adding a single data description</a>
+            </li>
+            <li class="gem-c-related-navigation__link">
+              <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other" href="/learn/articles/adding-a-CSV-file">Adding a collection of metadata records as a CSV file</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
 
 </div>
-{% endblock %}  
+{% endblock %}
 
 {% set customFooterContent %}
 <h2 id="support" class="govuk-heading-m">Get help and support</h2>
-<p class="govuk-body-s"><a class="govuk-footer__link" href="https://forms.gle/rpy2BMchHGDNVFfAA">Tell us what you need help with</a>.</p>
+<p class="govuk-body-s">
+<a class="govuk-footer__link" href="https://forms.gle/rpy2BMchHGDNVFfAA">Tell us what you need help with</a>.</p>
 <p class="govuk-body-s">If you have any questions about the data asset description (metadata), you should contact the data asset supplier directly.</p>
 {% endset %}
 
 {% set customFooterContent %}
 
 <h2 id="support" class="govuk-heading-m">Get help and support</h2>
-<p class="govuk-body-s"><a class="govuk-footer__link" href="https://forms.gle/rpy2BMchHGDNVFfAA">Tell us what you need help with</a>.</p>
+<p class="govuk-body-s">
+<a class="govuk-footer__link" href="https://forms.gle/rpy2BMchHGDNVFfAA">Tell us what you need help with</a>.</p>
 <p class="govuk-body-s">If you have any questions about the data asset description (metadata), you should contact the data asset supplier directly.</p>
 <ul class="govuk-footer__inline-list">
-    <li class="govuk-footer__inline-list-item">
-        <a class="govuk-footer__link" href="#">Accessibility</a>
-    </li>
-    <li class="govuk-footer__inline-list-item">
-        <a class="govuk-footer__link" href="#">Cookies</a>
-    </li>
-    <li class="govuk-footer__inline-list-item">
-        <a class="govuk-footer__link" href="#">Privacy</a>
-    </li>
+<li class="govuk-footer__inline-list-item">
+  <a class="govuk-footer__link" href="#">Accessibility</a>
+</li>
+<li class="govuk-footer__inline-list-item">
+  <a class="govuk-footer__link" href="#">Cookies</a>
+</li>
+<li class="govuk-footer__inline-list-item">
+  <a class="govuk-footer__link" href="#">Privacy</a>
+</li>
 </ul>
 {% endset %}
 


### PR DESCRIPTION
# Publish dashboard statistics
This PR adds functionality which calls the new API endpoint added in [this PR](https://github.com/co-cddo/data-marketplace-api/pull/47), to display correct numbers of published datasets and data services on the publish dashboard page

## Changes
- Call the new API endpoint and pass the numbers of datasets and data services to the `publish-dashboard` template.
- Remove the statistics related to share requests from the publish dashboard.
![image](https://github.com/co-cddo/data-marketplace/assets/1217533/9d8f76f7-c287-4c31-a229-926117ac9f60)
