### PR TITLE
Redirect to start if check page is not ready

### DIFF
--- a/src/routes/acquirerRoutes.ts
+++ b/src/routes/acquirerRoutes.ts
@@ -105,6 +105,13 @@ router.get("/:resourceID/check", async (req: Request, res: Response) => {
   }
 
   const formdata = req.session.acquirerForms[resourceID];
+  const stepData = formdata.steps["check"];
+  if (
+    stepData.status === "NOT REQUIRED" ||
+    stepData.status === "CANNOT START YET"
+  ) {
+    return res.redirect(`/acquirer/${resourceID}/start`);
+  }
 
   let returnedNotes, returnedNotesTitle;
   try {


### PR DESCRIPTION
Fixes a bug where the check page was trying to be displayed, even if the status was `CANNOT_START_YET`